### PR TITLE
I think this fixes issue #2.

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -96,6 +96,12 @@ sub pkgconfig {
 
   croak "No Alien::Base::PkgConfig objects are stored!"
     unless keys %all;
+  
+  # Run through all pkgconfig objects and ensure that their modules are loaded:
+  for my $pkg_obj (values %all) {
+    my $perl_module_name = blessed $pkg_obj;
+    eval "require $perl_module_name"; 
+  }
 
   return @all{@_} if @_;
 


### PR DESCRIPTION
Currently, pkgconfig objects (as stored in Alien::MyModule::ConfigData)
were properly pulling in their serialized selves and blessing
themselves into their proper ::PkgConfig classes. However, there
was no guarantee that the Perl module that implemented that class
was present. This change adds a check that runs through all
PkgConfig objects and loads the modules by the same name as their
blessing.

fixes #2
