### PR TITLE
Fix http protocol

### DIFF
--- a/lib/Alien/Base/ModuleBuild/Repository/HTTP.pm
+++ b/lib/Alien/Base/ModuleBuild/Repository/HTTP.pm
@@ -42,7 +42,7 @@ sub get_file {
   my $host = $self->{host};
   my $from = $self->location;
 
-  my $response = $self->connection->mirror( $host . $from . $file, $file );
+  my $response = $self->connection->mirror('http://' . $host . $from . '/' . $file, $file );
   croak "Download failed: " . $response->{reason} unless $response->{success};
 
   return 1;
@@ -52,18 +52,17 @@ sub list_files {
   my $self = shift;
 
   my $host = $self->host;
-  my $uri = URI->new($host);
+  my $location = $self->location;
+  my $uri = URI->new('http://' . $host . $location);
 
-  my $res = $self->connection->get($uri->abs($self->location));
+  my $res = $self->connection->get($uri);
 
   unless ($res->{success}) {
     carp $res->{reason};
     return ();
   }
 
-  my @links = 
-    map { $uri->abs($_) }
-    $self->find_links($res->{content});
+  my @links = $self->find_links($res->{content});
 
   return @links;  
 }


### PR DESCRIPTION
It looks like Alien::Base::ModuleBuild::Repository::HTTP wasn't using the URI module properly.  This commit adds 'http' as the schema and removes the use of $uri->abs.

If the href's found by find_links are not relative, they may not be handled properly.  I'll submit another pull request if I can fix that.
