### PR TITLE
t/zz-example.t required ExtUtils::LibBuilder

### DIFF
--- a/t/zz-example.t
+++ b/t/zz-example.t
@@ -5,7 +5,7 @@ use Test::More;
 
 use File::chdir;
 
-unless( eval { use ExtUtils::LibBuilder; 1 } ) {
+unless( eval "use ExtUtils::LibBuilder; 1" ) {
   plan skip_all => "libdontpanic requires ExtUtils::LibBuilder";
 }
 


### PR DESCRIPTION
The block syntax for eval still fails if used modules aren't available, so the lack of ExtUtils::LibBuilder was making the test fail.
