### PR TITLE
add bin (if it exists) directory to PATH on win32

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -61,7 +61,7 @@ sub import {
     if($^O eq 'cygwin') {
       $ENV{PATH} = "$dist_dir/bin:$ENV{PATH}";
     } else {
-      $ENV{PATH} = "$dist_dir/bin;$ENV{PATH}";
+      $ENV{PATH} = "$dist_dir\\bin;$ENV{PATH}";
     }
   }
 


### PR DESCRIPTION
in order to use .dlls on MSWin32 and cygwin, they must be in the PATH.  This patch adds the bin directory, where the dlls are normally placed, if it exists.

The only downside to this I can see is that there may be some unwanted .exe files in the bin directory as well, at the cost of some complexity, it may pay do one of:
- make this optional (though windows dll won't work without it)
- remove .exe files from bin
- copy/move .dll files to an alternate directory and put THAT directory in the PATH
