### PR TITLE
Add configuration type to item under test

### DIFF
--- a/t/validation.t
+++ b/t/validation.t
@@ -5,9 +5,10 @@ use Test::More;
 
 use_ok('Alien::Base::ModuleBuild');
 
-my $builder = bless {
-  config => 'Module::Build::Config',
-}, 'Alien::Base::ModuleBuild';
+my $builder = Alien::Base::ModuleBuild->new(
+  module_name  => 'My::Test::Module',
+  dist_version => '1.234.567',
+);
 
 ok( $builder->alien_validate_repo( {platform => undef} ), "undef validates to true");
 


### PR DESCRIPTION
Add configuration class that Module::Build is able to use.

See Perl-Toolchain-Gang/Module-Build@ffdcbb57af5bca0f319177b9d0164581da70605c for the commit that started this behavior.
