### PR TITLE
fix the splitting of linker flags on Windows

### DIFF
--- a/t/build_flags.t
+++ b/t/build_flags.t
@@ -1,0 +1,27 @@
+use Test::More;
+
+use Alien::Base ();
+
+my %unix_flags = (
+  q{ -L/a/b/c -lz -L/a/b/c } => [ "-L/a/b/c", "-lz", "-L/a/b/c" ],
+);
+
+my %win_flags = (
+  q{ -L/a/b/c -lz -L/a/b/c } => [ "-L/a/b/c", "-lz", "-L/a/b/c" ],
+  q{ -LC:/a/b/c -lz -L"C:/a/b c/d" } => [ "-LC:/a/b/c", "-lz", "-LC:/a/b c/d" ],
+  q{ -LC:\a\b\c -lz } => [ q{-LC:\a\b\c}, "-lz" ],
+);
+
+subtest 'unix' => sub {
+  while ( my ($flag, $split) = each %unix_flags ) {
+    is_deeply( [ Alien::Base->split_flags_unix( $flag ) ], $split );
+  }
+};
+
+subtest 'windows' => sub {
+  while ( my ($flag, $split) = each %win_flags ) {
+    is_deeply( [ Alien::Base->split_flags_windows( $flag ) ], $split );
+  }
+};
+
+done_testing;


### PR DESCRIPTION
This should address issue https://github.com/Perl5-Alien/Alien-Base/issues/41.

I would prefer this to use a separate module that can parse cmd.exe command lines, but that would be overkill right now. Let's see how this changes the Alien::Base downstream users on Windows. There should be no change for Unix.
