### PR TITLE
add property alien_isolate_dynamic

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -12,6 +12,7 @@ use Carp;
 use DynaLoader ();
 
 use File::ShareDir ();
+use File::Spec;
 use Scalar::Util qw/blessed/;
 use Capture::Tiny 0.17 qw/capture_merged/;
 use Text::ParseWords qw/shellwords/;
@@ -192,6 +193,16 @@ sub split_flags_windows {
   # backslashes are not used to escape metacharacters in cmd.exe.
   $line =~ s,\\,\\\\,g;
   shellwords($line);
+}
+
+sub dynamic_lib {
+  my ($class) = @_;
+  my $dir = File::Spec->catfile($class->dist_dir, 'dynamic');
+  return unless -d $dir;
+  opendir(my $dh, $dir);
+  my @dlls = grep { /\.so/ || /\.(dylib|dll)$/ } grep !/^\./, readdir $dh;
+  closedir $dh;
+  grep { ! -l $_ } map { File::Spec->catfile($dir, $_) } @dlls;
 }
 
 1;

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -71,6 +71,12 @@ These parameters, if specified, augment the information found by F<pkg-config>. 
 
 A hashref or arrayref of hashrefs defining the repositories used to find and fetch library tarballs (or zipballs etc.). These attributes are used to create C<Alien::Base::ModuleBuild::Repository> objects (or more likely, subclasses thereof). Which class is created is governed by the C<protocol> attribute and the C<alien_repository_class> property below. Available attributes are:
 
+=item alien_isolate_dynamic
+
+[version 0.005]
+
+If set to true, then dynamic libraries will be moved from the C<lib> directory to a separate C<dynamic> directory.  This makes them available for FFI modules (see L<FFI::Raw>), while preferring static libraries when creating XS extensions.
+
 =over
 
 =item protocol


### PR DESCRIPTION
This is my proposed solution for #11.  It isolates the dynamic libraries into a separate directory so they will not be considered when creating XS modules.  This is only done when alien_isolate_dynamic is set to true.  For this to be useful, the author of a `Alien::Foo` module will need to build position independent code on platforms that require it, in which case also accepting #47 or something similar will be highly desirable.

There are a number of advantages to forcing static libraries when building XS modules:
1. upgrades to `Alien::Foo` will no longer break `Foo::XS`.  The downside is that `Foo::XS` will still be using the old version of `libfoo`, but I believe this is better than breaking the module.
2. `Alien::Foo` is no longer a run time dep for `Foo::XS` (just a build dep) so there is less to load
3. The method that currently AB uses for including dynamic libraries in platform specific search paths is broken on some platforms, such as Solaris (#50) and Windows (#32).  Though this is probably solvable.

There are also risks, but given that this `alien_isolate_dynamic` is optional they seem to be minimal.

That being said I think there is an argument for making `alien_isolate_dynamic` true by default, if not immediately, then some time down the road.  I think the number of `Alien::Foo` type dists that would benefit from this feature is probably larger than the number with risks.
