### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: perl
 install:
   - git clone https://github.com/Perl5-Alien/Alien-Base-Extras.git
   - tar xf Alien-Base-Extras/Acme-Alien-DontPanic/inc/dontpanic-1.0.tar.gz
-  - cd dontpanic
+  - cd dontpanic-1.0
   - ./configure
   - make
   - sudo make install


### PR DESCRIPTION
The more conventional build for dontpanic in `Alien-Base-Extras` broke the travis build.  I will merge this as soon as I get a good build from travis, unless there are objections.
