### PR TITLE
more MSWin32 path fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl module Alien::Base.
 
+  - additional use / instead of \ on MSWin32 (plicease gh#68)
+
 0.004_04  Sep 09, 2014
   - fixed test error introduced in 0.004_03 expressed on cygwin (plicease gh#67)
 

--- a/lib/Alien/Base/PkgConfig.pm
+++ b/lib/Alien/Base/PkgConfig.pm
@@ -27,6 +27,7 @@ sub new {
   my ($name, $dir) = fileparse $path, '.pc';
 
   $dir = File::Spec->catdir( $dir );  # remove trailing slash
+  $dir =~ s{\\}{/}g;
 
   my $self = {
     package  => $name,


### PR DESCRIPTION
This corrects problem paths that I was seeing in `Alien::LibXML`:

```
 t\00-use.t ....... ok
 # COMPILER: N:\lang\perl\strawberry\x86\5.18.2\ccache\bin\gcc.EXE
 # CFLAGS:   -IN:/home/ollisg/perl5/strawberry/x86/5.18.2/lib/perl5/auto/share/dist/Alien-LibXML/include/libxml2 -IN:homeollisgdevAlien-LibXML_alienlibxml2-2.9.1/include -IN:homeollisgdevAlien-LibXML_alienlibxml2-2.9.1/include/libxml2
 # LIBS:     -LN:homeollisgdevAlien-LibXML_alienlibxml2-2.9.1 -lxml2 -lz -liconv -LN:/home/ollisg/perl5/strawberry/x86/5.18.2/lib/perl5/auto/share/dist/Alien-LibXML/lib -lxml2
 # OUTPUT:   t/tree1.exe
 # INPUT:    t/tree1.c
 t\01-compiler.t .. ok
 All tests successful.
 Files=2, Tests=3,  2 wallclock secs ( 0.06 usr +  0.00 sys =  0.06 CPU)
```

note `-IN:homeollisgdevAlien-LibXML_alienlibxml2-2.9.1/include`

Although the test succeeded it was because it was actually linking against the libxml2 that came with strawberry Perl, even thought this was a `ALIEN_FORCE=1` build and was thus actually covering up a bug in the test.
