### PR TITLE
support in PkgConfig for --list-all started with 0.07520

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -49,7 +49,7 @@ my %build_args = (
 );
 
 unless (`pkg-config --version` && $? == 0) {
-  $build_args{'requires'}->{'PkgConfig'} = 0;
+  $build_args{'requires'}->{'PkgConfig'} = '0.07520';
 }
 
 my $builder = Module::Build->new(%build_args);


### PR DESCRIPTION
I believe this to be uncontroversial and will thus merge.  PR for visibility.  Noticed this when trying to install Alien::Base on a system that had an older PkgConfig.pm (and apparently without pkg-config).
