### PR TITLE
Inline integration requires Inline 0.56

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -87,7 +87,8 @@ You can even use it with L<Inline> (C and C++ languages are supported):
  package MyLibrary::Inline;
  
  use Alien::MyLibrary;
- use Inline with => 'Alien::MyLibrary';
+ # Inline 0.56 or better is required
+ use Inline 0.56 with => 'Alien::MyLibrary';
  ...
 
 =head1 DESCRIPTION

--- a/t/inline.t
+++ b/t/inline.t
@@ -3,14 +3,14 @@ use warnings;
 use Test::More;
 
 BEGIN {
-  eval { require Inline; require Inline::C; } || plan skip_all => 'test requires Inline and Inline::C';
+  eval q{ use Inline 0.56 (); require Inline::C; } || plan skip_all => 'test requires Inline 0.56 and Inline::C';
   eval q{ use Acme::Alien::DontPanic 0.007; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.007' . $@;
   plan skip_all => 'test requires that Acme::Alien::DontPanic was build with Alien::Base 0.006'
     unless defined Acme::Alien::DontPanic->Inline("C")->{AUTO_INCLUDE};
 }
 
 use Acme::Alien::DontPanic;
-use Inline with => 'Acme::Alien::DontPanic';
+use Inline 0.56 with => 'Acme::Alien::DontPanic';
 use Inline C => 'DATA', ENABLE => 'AUTOWRAP';
 
 is string_answer(), "the answer to life the universe and everything is 42", "indirect call";

--- a/t/inline_cpp.t
+++ b/t/inline_cpp.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 
 BEGIN {
-  eval { require Inline; require Inline::CPP; } || plan skip_all => 'test requires Inline and Inline::CPP';
+  eval q{ use Inline 0.56 (); require Inline::CPP; } || plan skip_all => 'test requires Inline 0.56 and Inline::CPP';
   eval q{ use Acme::Alien::DontPanic 0.007; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.007';
   plan skip_all => 'test requires that Acme::Alien::DontPanic was build with Alien::Base 0.006'
     unless defined Acme::Alien::DontPanic->Inline("CPP")->{AUTO_INCLUDE};
@@ -11,7 +11,7 @@ BEGIN {
 
 
 use Acme::Alien::DontPanic;
-use Inline with => 'Acme::Alien::DontPanic';
+use Inline 0.56 with => 'Acme::Alien::DontPanic';
 use Inline CPP => 'DATA', ENABLE => 'AUTOWRAP';
 
 is Foo->new->string_answer, "the answer to life the universe and everything is 42", 'indirect';


### PR DESCRIPTION
This fixes feature #71 so that it only tests `Inline` integration when the version installed is sufficient.  Also document the fact that you need a pretty new version of `Inline` in the synopsis.

Merging since this is a fix to an already agreed to feature.  PR for visibility.
