### PR TITLE
allow for MSYS without %c

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -111,6 +111,9 @@ __PACKAGE__->add_property( 'alien_autoconf_with_pic' => 1 );
 # alien_inline_auto_include
 __PACKAGE__->add_property( 'alien_inline_auto_include' => [] );
 
+# use MSYS even if %c isn't found
+__PACKAGE__->add_property( 'alien_msys' => 0 );
+
 ################
 #  ConfigData  #
 ################
@@ -149,7 +152,7 @@ sub new {
     $self->config_data( 'autoconf' => 1 );
   }
 
-  if ($^O eq 'MSWin32' && $self->config_data( 'autoconf')) {
+  if ($^O eq 'MSWin32' && ($self->config_data( 'autoconf') || $self->alien_msys)) {
     $self->_add_prereq( 'build_requires', 'Alien::MSYS', '0' );
     $self->config_data( 'msys' => 1 );
   } else {

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -144,6 +144,12 @@ Unlike most L<Module::Build> parameters, authors may specify only those keys whi
 
 Array reference containing the list of header files to be used automatically by C<Inline::C> and C<Inline::CPP>.
 
+=item alien_msys
+
+[version 0.006]
+
+On windows wrap build and install commands in an C<MSYS> environment using L<Alien::MSYS>.  This option will automatically add L<Alien::MSYS> as a build requirement when building on Windows.
+
 =back
 
 =head2 PACKAGE AND ENVIRONMENT VARIABLES


### PR DESCRIPTION
Sometimes you might want/need MSYS on windows even though you aren't using autoconf.

Me: **aye**
