### PR TITLE
print out commands before they are executed

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -593,6 +593,8 @@ sub alien_do_commands {
   my $attr = "alien_${phase}_commands";
   my $commands = $self->$attr();
 
+  print "\n+ cd $CWD\n";
+
   foreach my $command (@$commands) {
 
     my %result = $self->_env_do_system( $command );
@@ -618,6 +620,8 @@ sub do_system {
   my $initial_cwd = $CWD;
 
   my @args = map { $self->alien_interpolate($_) } @_;
+
+  print "+ @args\n";
 
   my ($out, $err, $success) = 
     $verbose


### PR DESCRIPTION
You can get the commands as they are executed by supplying the verbose=1 option to MB.  However, I find this is actually pretty hard to read from the log.
- The "+ " prefix _a la_ `sh -x` option helps visually distinguish commands from output
- Turning it on by default makes troubleshooting cpantesters testers (or user reports) easier due to additional information.
