### PR TITLE
Only inject alien_bin_requires and Alien::MSYS prereqs if a source code build is necessary.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl module Alien::Base.
 
+  - alien_bin_requires only become build_requires if Alien::Base::ModuleBuild determines
+    a source build is necessary (plicease gh#96)
+  - On MSWin32, Alien::MSYS is only injected a prereq if Alien::Base::ModuleBuild determines
+    a source build is necessary and autoconf is detected (plicease gh#96)
+
 0.006_01  Nov 14, 2014
   - Add support for Alien::Base dynamic_libs method for system installs
     (previously only share install was supported)

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -158,19 +158,21 @@ sub new {
   # be used by the auto_include method
   $self->config_data( 'inline_auto_include' => $self->alien_inline_auto_include );
 
-  if (grep /(?<!\%)\%c/, @{ $self->alien_build_commands }) {
-    $self->config_data( 'autoconf' => 1 );
-  }
+  if($Force || !$self->alien_check_installed_version) {
+    if (grep /(?<!\%)\%c/, @{ $self->alien_build_commands }) {
+      $self->config_data( 'autoconf' => 1 );
+    }
 
-  if ($^O eq 'MSWin32' && ($self->config_data( 'autoconf') || $self->alien_msys)) {
-    $self->_add_prereq( 'build_requires', 'Alien::MSYS', '0' );
-    $self->config_data( 'msys' => 1 );
-  } else {
-    $self->config_data( 'msys' => 0 );
-  }
+    if ($^O eq 'MSWin32' && ($self->config_data( 'autoconf') || $self->alien_msys)) {
+      $self->_add_prereq( 'build_requires', 'Alien::MSYS', '0' );
+      $self->config_data( 'msys' => 1 );
+    } else {
+      $self->config_data( 'msys' => 0 );
+    }
   
-  while(my($tool, $version) = each %{ $self->alien_bin_requires }) {
-    $self->_add_prereq( 'build_requires', $tool, $version );
+    while(my($tool, $version) = each %{ $self->alien_bin_requires }) {
+      $self->_add_prereq( 'build_requires', $tool, $version );
+    }
   }
 
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -168,6 +168,10 @@ On windows wrap build and install commands in an C<MSYS> environment using L<Ali
 
 Hash reference of modules (keys) and versions (values) that specifies C<Alien> modules that provide binary tools that are required to build.  Any L<Alien::Base> module that includes binaries should work.  Also supported are L<Alien::MSYS>, L<Alien::CMake>, L<Alien::TinyCC> and L<Alien::Autotools>.
 
+[version 0.007]
+
+These only become required for building if L<Alien::Base::ModuleBuild> determines that a source code build is required.
+
 =back
 
 =head2 PACKAGE AND ENVIRONMENT VARIABLES

--- a/t/builder.t
+++ b/t/builder.t
@@ -262,4 +262,57 @@ EOF
   rmtree [qw/ _alien  _share  blib  src /], 0, 0;
 };
 
+subtest 'source build requires' => sub {
+
+  local $mb_class = do {
+    package My::MBBuildRequiresExample1;
+
+    use base qw( Alien::Base::ModuleBuild );
+
+    sub alien_check_installed_version
+    {
+      return;
+    }
+
+    __PACKAGE__;
+  };
+
+  subtest 'not installed, not forced' => sub {
+    local $Alien::Base::ModuleBuild::Force = 0;
+    my $builder = builder( alien_bin_requires => { 'Foo::Bar' => '1.1' } );
+    is $builder->build_requires->{"Foo::Bar"}, '1.1', 'Foo::Bar = 1.1';
+  };
+
+  subtest 'not installed, forced' => sub {
+    local $Alien::Base::ModuleBuild::Force = 1;
+    my $builder = builder( alien_bin_requires => { 'Foo::Bar' => '1.1' } );
+    is $builder->build_requires->{"Foo::Bar"}, '1.1', 'Foo::Bar = 1.1';
+  };
+
+  local $mb_class = do {
+    package My::MBBuildRequiresExample2;
+
+    use base qw( Alien::Base::ModuleBuild );
+
+    sub alien_check_installed_version
+    {
+      return '1.2';
+    }
+
+    __PACKAGE__;
+  };
+
+  subtest 'installed, not forced' => sub {
+    local $Alien::Base::ModuleBuild::Force = 0;
+    my $builder = builder( alien_bin_requires => { 'Foo::Bar' => '1.1' } );
+    is $builder->build_requires->{"Foo::Bar"}, undef, 'Foo::Bar = undef';
+  };
+
+  subtest 'installed, forced' => sub {
+    local $Alien::Base::ModuleBuild::Force = 1;
+    my $builder = builder( alien_bin_requires => { 'Foo::Bar' => '1.1' } );
+    is $builder->build_requires->{"Foo::Bar"}, '1.1', 'Foo::Bar = 1.1';
+  };
+};
+
 done_testing;


### PR DESCRIPTION
This saves installing unnecessary prereqs if we know they are not needed.

Example savings: Strawberry Perl comes with libffi now, so you don't need Alien::MSYS to install Alien::FFI.