### PR TITLE
add support for HTTPS repositories

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -38,6 +38,7 @@ use Alien::Base::ModuleBuild::Repository::Local;
 my %default_repository_class = (
   default => 'Alien::Base::ModuleBuild::Repository',
   http    => 'Alien::Base::ModuleBuild::Repository::HTTP',
+  https   => 'Alien::Base::ModuleBuild::Repository::HTTP',
   ftp     => 'Alien::Base::ModuleBuild::Repository::FTP',
   local   => 'Alien::Base::ModuleBuild::Repository::Local',
 );

--- a/lib/Alien/Base/ModuleBuild/Repository.pm
+++ b/lib/Alien/Base/ModuleBuild/Repository.pm
@@ -51,7 +51,7 @@ sub probe {
     @files = $self->list_files();
 
     if ($pattern) {
-	@files = grep { $_ =~ $pattern } @files;
+      @files = grep { $_ =~ $pattern } @files;
     }
 
     carp "Could not find any matching files" unless @files;

--- a/t/http_uri.t
+++ b/t/http_uri.t
@@ -8,37 +8,42 @@ use_ok('Alien::Base::ModuleBuild::Repository::HTTP');
 my $repo = Alien::Base::ModuleBuild::Repository::HTTP->new;
 
 {
-  my $uri = $repo->build_uri('host.com', 'path');
+  my $uri = $repo->build_uri('http','host.com', 'path');
   is $uri, 'http://host.com/path', 'simplest case';
 }
 
 {
-  my $uri = $repo->build_uri('host.com', 'my path');
+  my $uri = $repo->build_uri('https','host.com', 'path');
+  is $uri, 'https://host.com/path', 'simplest case with the HTTPS protocol';
+}
+
+{
+  my $uri = $repo->build_uri('http','host.com', 'my path');
   is $uri, 'http://host.com/my%20path', 'path with spaces';
 }
 
 {
-  my $uri = $repo->build_uri('host.com', 'deeper', 'my path');
+  my $uri = $repo->build_uri('http','host.com', 'deeper', 'my path');
   is $uri, 'http://host.com/deeper/my%20path', 'extended path with spaces';
 }
 
 {
-  my $uri = $repo->build_uri('host.com/', '/path');
+  my $uri = $repo->build_uri('http','host.com/', '/path');
   is $uri, 'http://host.com/path', 'remove repeated /';
 }
 
 {
-  my $uri = $repo->build_uri('host.com/', '/path/', 'file.ext');
+  my $uri = $repo->build_uri('http','host.com/', '/path/', 'file.ext');
   is $uri, 'http://host.com/path/file.ext', 'file with path';
 }
 
 {
-  my $uri = $repo->build_uri('host.com/', '/path/', 'http://host.com/other/file.ext');
+  my $uri = $repo->build_uri('http','host.com/', '/path/', 'http://host.com/other/file.ext');
   is $uri, 'http://host.com/other/file.ext', 'absolute URI found in link';
 }
 
 {
-  my $uri = $repo->build_uri('host.com/', '/path/', 'http://example.org/other/file.ext');
+  my $uri = $repo->build_uri('http','host.com/', '/path/', 'http://example.org/other/file.ext');
   is $uri, 'http://example.org/other/file.ext', 'absolute URI on different host';
 }
 


### PR DESCRIPTION
This adds support for HTTPS repositories since both `HTTP::Tiny` and
`LWP::UserAgent` can support the HTTPS protocol. This change adds to the
`Alien::Base::ModuleBuild::Repository::HTTP` repository class.