### PR TITLE
prefer FFI::Platypus to FFI::Raw in documentation

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -86,11 +86,12 @@ Or you can use it from an FFI module:
  package MyLibrary::FFI;
  
  use Alien::MyLibrary;
- use FFI::Raw;
+ use FFI::Platypus;
  
- my($dll) = Alien::MyLibrary->dynamic_libs;
+ my $ffi = FFI::Platypus->new;
+ $ffi->lib(Alien::MyLibrary->dynamic_libs);
  
- FFI::Raw->new($dll, 'my_library_function', FFI::Raw::void);
+ $ffi->attach( 'my_library_function' => [] => 'void' );
 
 You can even use it with L<Inline> (C and C++ languages are supported):
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -123,7 +123,7 @@ If true (the default), then a C compiler is required to build from source.
 
 [version 0.005]
 
-If set to true, then dynamic libraries will be moved from the C<lib> directory to a separate C<dynamic> directory.  This makes them available for FFI modules (see L<FFI::Raw>), while preferring static libraries when creating XS extensions.
+If set to true, then dynamic libraries will be moved from the C<lib> directory to a separate C<dynamic> directory.  This makes them available for FFI modules (see L<FFI::Platypus>, or L<FFI::Raw>), while preferring static libraries when creating XS extensions.
 
 =item alien_autoconf_with_pic
 


### PR DESCRIPTION
Now that `FFI::Platypus` is on CPAN I'd like to prefer it in the Alien::Base documentation over `FFI::Raw`.

Full disclosure: I am the author of `FFI::Platypus` (but patches welcome!)

Platypus is newer than Raw, but it has some significant performance advantages and a number of features that Raw lacks.