### PR TITLE
./Build alien_dry_run

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -225,7 +225,7 @@ END
 #  ACTION methods  #
 ####################
 
-sub ACTION_alien_dry_run {
+sub ACTION_alien_fakebuild {
   my $self = shift;
 
   print "# Build\n";

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -225,6 +225,21 @@ END
 #  ACTION methods  #
 ####################
 
+sub ACTION_alien_dry_run {
+  my $self = shift;
+
+  print "# Build\n";
+  foreach my $cmd (map { $self->alien_interpolate($_) } @{ $self->alien_build_commands })
+  {
+    print "+ $cmd\n";
+  }
+  print "# Build install\n";
+  foreach my $cmd (map { $self->alien_interpolate($_) } @{ $self->alien_install_commands })
+  {
+    print "+ $cmd\n";
+  }
+}
+
 sub ACTION_code {
   my $self = shift;
   $self->notes( 'alien_blib_scheme' => $self->alien_detect_blib_scheme );

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -229,14 +229,16 @@ sub ACTION_alien_dry_run {
   my $self = shift;
 
   print "# Build\n";
-  foreach my $cmd (map { $self->alien_interpolate($_) } @{ $self->alien_build_commands })
+  foreach my $cmd (@{ $self->alien_build_commands })
   {
-    print "+ $cmd\n";
+    my @cmd = map { $self->alien_interpolate($_) } ref($cmd) ? @$cmd : ($cmd);
+    print "+ @cmd\n";
   }
   print "# Build install\n";
-  foreach my $cmd (map { $self->alien_interpolate($_) } @{ $self->alien_install_commands })
+  foreach my $cmd (@{ $self->alien_install_commands })
   {
-    print "+ $cmd\n";
+    my @cmd = map { $self->alien_interpolate($_) } ref($cmd) ? @$cmd : ($cmd);
+    print "+ @cmd\n";
   }
 }
 


### PR DESCRIPTION
Debugging a issue with `Alien::FFI` on MSWin32 and it was useful to be able to see the commands as they would actually be executed, without actually executing, so I added an ACTION_alien_dry_run.

Its not quite as clever as I would like it to be (ie, would be nice to probe the repositories and tell me exactly which one(s) it would download), but I think this is a good start.