### PR TITLE
allow for multiple argument do_system

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -160,7 +160,7 @@ sub new {
   $self->config_data( 'inline_auto_include' => $self->alien_inline_auto_include );
 
   if($Force || !$self->alien_check_installed_version) {
-    if (grep /(?<!\%)\%c/, @{ $self->alien_build_commands }) {
+    if (grep /(?<!\%)\%c/, map { ref($_) ? @{$_} : $_ } @{ $self->alien_build_commands }) {
       $self->config_data( 'autoconf' => 1 );
     }
 
@@ -618,7 +618,7 @@ sub _env_do_system {
 
   }
   
-  $self->do_system( $command );
+  $self->do_system( ref($command) ? @$command : $command );
 }
 
 sub alien_check_built_version {

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -53,11 +53,19 @@ This is intended to choose the mechanism for selecting one file from many. The d
 
 An arrayref of commands used to build the library in the directory specified in C<alien_temp_dir>. Each command is first passed through the L<command interpolation engine|/"COMMAND INTERPOLATION">, so those variables may be used. The default is tailored to the Gnu toolchain, i.e. AutoConf and Make; it is C<[ '%c --prefix=%s', 'make' ]>.
 
+[version 0.009]
+
+Each command may be either a string or a list reference.  If the list reference form is used then the multiple argument form of C<system> is used.  Prior to version 0.009, only the string form was supported.
+
 =item alien_install_commands
 
 [version 0.001]
 
 An arrayref of commands used to install it to the share directory specified by interpolation var C<%s>. Each command is first passed through the L<command interpolation engine|/"COMMAND INTERPOLATION">, so those variables may be used. The default is tailored to the Gnu toolchain, i.e. AutoConf and Make; it is C<[ 'make install' ]>.
+
+[version 0.009]
+
+Each command may be either a string or a list reference.  If the list reference form is used then the multiple argument form of C<system> is used.  Prior to version 0.009, only the string form was supported.
 
 =item alien_version_check
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -55,7 +55,7 @@ An arrayref of commands used to build the library in the directory specified in 
 
 [version 0.009]
 
-Each command may be either a string or a list reference.  If the list reference form is used then the multiple argument form of C<system> is used.  Prior to version 0.009, only the string form was supported.
+Each command may be either a string or a array reference.  If the array reference form is used then the multiple argument form of C<system> is used.  Prior to version 0.009, only the string form was supported.
 
 =item alien_install_commands
 
@@ -65,7 +65,7 @@ An arrayref of commands used to install it to the share directory specified by i
 
 [version 0.009]
 
-Each command may be either a string or a list reference.  If the list reference form is used then the multiple argument form of C<system> is used.  Prior to version 0.009, only the string form was supported.
+Each command may be either a string or a array reference.  If the array reference form is used then the multiple argument form of C<system> is used.  Prior to version 0.009, only the string form was supported.
 
 =item alien_version_check
 


### PR DESCRIPTION
This patch allows for use of the multiple argument form of `system`.  Sometimes this is desirable:

  - the multiple argument form doesn't usually invoke the shell
  - quoting is not portable, so the multiple argument version is frequently the more portable way to introduce space into an argument

I'd be using this in `Alien::FFI` which has some pretty hairy stuff for Windows and especially for Visual C++ support.