### PR TITLE
New diagnostics

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl module Alien::Base.
 
+  - Added diagnostics for Alien authors to help in diagnosing common configuration problems.
+
 0.009_01  Jan 27, 2015
   - Added './Build alien_fakebuild' command which shows you what would be executed without actually doing it (plicease gh#102)
 

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -108,7 +108,7 @@ __PACKAGE__->add_property( 'alien_provides_libs' );
 #   |-- platform: src or platform, matching os_type M::B method
 #   |
 #   |-- (non-api) connection: holder for Net::FTP-like object (needs cwd, ls, and get methods)
-__PACKAGE__->add_property( 'alien_repository'         => {} );
+__PACKAGE__->add_property( 'alien_repository'         => [] );
 __PACKAGE__->add_property( 'alien_repository_default' => {} );
 __PACKAGE__->add_property( 'alien_repository_class'   => {} );
 
@@ -358,6 +358,10 @@ sub ACTION_alien_code {
   }
 
   if (! $version and ! $pc_version) {
+    print STDERR "If you are the author of this Alien dist, you may need to provide a an\n";
+    print STDERR "alien_check_built_version method for your Alien::Base::ModuleBuild\n";
+    print STDERR "class.  See:\n";
+    print STDERR "https://metacpan.org/pod/Alien::Base::ModuleBuild#alien_check_built_version\n";
     carp "Library looks like it installed, but no version was determined";
     $self->config_data( version => 0 );    
     return
@@ -491,6 +495,14 @@ sub alien_create_repositories {
   # upconvert to arrayref if a single hashref is passed
   if (ref $repo_specs eq 'HASH') {
     $repo_specs = [ $repo_specs ];
+  }
+  
+  unless(@$repo_specs)
+  {
+    print STDERR "If you are the author of this Alien dist, you need to provide at least\n";
+    print STDERR "one repository in your Build.PL.  See:\n";
+    print STDERR "https://metacpan.org/pod/distribution/Alien-Base/lib/Alien/Base/ModuleBuild/API.pod#alien_repository\n";
+    croak "No repositories specified.";
   }
 
   my @repos;


### PR DESCRIPTION
These diagnostics would have saved me some time tonight.

The diagnostic about requiring at least one repository is fatal either way, it is just that it catches it earlier with this patch.  IF we want to support builds that lack any repositories then we need to restructure the code so that we can do that.  I don't see that it is a useful thing to do.

The other diagnostic just gives a hint as to what you need to do.  Even though I kind of know what needed to be done, I couldn't remember what the method I had to implement in order to get it to work.  If someone else were trying to use it they'd have even more trouble since they hadn't implemented it :)