### PR TITLE
Better support for ffi via dynamic_libs

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -31,7 +31,7 @@ my %build_args = (
     'Text::ParseWords' => '3.26',
     'Shell::Guess'     => 0,
     'Shell::Config::Generate' => 0,
-    'FFI::CheckLib'    => 0,
+    'FFI::CheckLib'    => 0.11,
   },
   test_requires => {
     'Test::More'       => 0.94,


### PR DESCRIPTION
This improves the `dynamic_libs` method to be more reliable, especially under `blib` conditions for cpantesters.  Just to give you an idea I added a similar feature as a monkey patch to `Acme::Ford::Prefect::FFI` and just take a look at the differences in the testing matrix before:

http://matrix.cpantesters.org/?dist=Acme-Ford-Prefect-FFI%200.08

after:

http://matrix.cpantesters.org/?dist=Acme-Ford-Prefect-FFI%200.09

This patch also has the nice in that it moves the "what is a dynamic library" logic into `FFI::CheckLib`, which is much more reliable in this regard (it knows about .bundle files for example which can be used on OS X in addition to .dylib) than either the old implementation of `dynamic_libs` or `Config` (which was at one point a suggestion).