### PR TITLE
skip inline* tests when Acme::Alien::DontPanic has an obviously bad dist_dir

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -114,7 +114,9 @@ sub import {
   my $class = shift;
 
   return if $class->install_type('system');
-  
+
+  # Sanity check in order to ensure that dist_dir can be found.
+  # This will throw an exception otherwise.  
   $class->dist_dir;
 
   # get a reference to %Alien::MyLibrary::AlienLoaded

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -114,6 +114,8 @@ sub import {
   my $class = shift;
 
   return if $class->install_type('system');
+  
+  $class->dist_dir;
 
   # get a reference to %Alien::MyLibrary::AlienLoaded
   # which contains names of already loaded libraries

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -181,6 +181,9 @@ sub dist_dir {
       ? File::ShareDir::dist_dir($dist) 
       : $class->config('working_directory');
 
+  croak "Failed to find share dir for dist '$dist'"
+    unless -d $dist_dir;
+
   return $dist_dir;
 }
 

--- a/t/inline.t
+++ b/t/inline.t
@@ -4,7 +4,7 @@ use Test::More;
 
 BEGIN {
   eval q{ use Inline 0.56 (); require Inline::C; } || plan skip_all => 'test requires Inline 0.56 and Inline::C';
-  eval q{ use Acme::Alien::DontPanic 0.010; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.010' . $@;
+  eval q{ use Acme::Alien::DontPanic 0.010; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.010 :' . $@;
   plan skip_all => 'test requires that Acme::Alien::DontPanic was build with Alien::Base 0.006'
     unless defined Acme::Alien::DontPanic->Inline("C")->{AUTO_INCLUDE};
 }

--- a/t/inline_cpp.t
+++ b/t/inline_cpp.t
@@ -4,7 +4,7 @@ use Test::More;
 
 BEGIN {
   eval q{ use Inline 0.56 (); require Inline::CPP; } || plan skip_all => 'test requires Inline 0.56 and Inline::CPP';
-  eval q{ use Acme::Alien::DontPanic 0.010; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.010';
+  eval q{ use Acme::Alien::DontPanic 0.010; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.010 :' . $@;
   plan skip_all => 'test requires that Acme::Alien::DontPanic was build with Alien::Base 0.006'
     unless defined Acme::Alien::DontPanic->Inline("CPP")->{AUTO_INCLUDE};
 }


### PR DESCRIPTION
This would probably have fixed this test failure:

http://ppm4.activestate.com/x86_64-linux/5.20/2000/P/PL/PLICEASE/Alien-Base-0.010.d/log20150217T080630.txt

Looks like it is trying to use a blib install gone bad.  Isolating the problem with Acme::Alien::DontPanic would ultimately be good, but I don't want that to block a working Alien::Base install.