### PR TITLE
bin_dir should only consult dist_dir if it is a share install

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -440,6 +440,7 @@ get installed into non-standard locations.
 
 sub bin_dir {
   my ($class) = @_;
+  return unless $class->install_type('share');
   my $dir = File::Spec->catfile($class->dist_dir, 'bin');
   -d $dir ? ($dir) : ();
 }


### PR DESCRIPTION
After releasing 0.011 I noticed almost immediately that installs with bin_dir and install_type=system were failing.

This will fix that.  I am merging to get this fix out right away because I consider it critical, making it a PR for visibility.