### PR TITLE
prefer PkgConfig.pm over pkg-config on 64 bit Solaris

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-
+use Config;
 use Module::Build;
 
 my %build_args = (
@@ -58,6 +58,10 @@ my %build_args = (
 
 unless (`pkg-config --version` && $? == 0) {
   $build_args{'requires'}->{'PkgConfig'} = '0.07520';
+}
+
+if($^O eq 'solaris' && $Config{ptrsize} == 8) {
+  $build_args{'requires'}->{'PkgConfig'} = '0.08826';
 }
 
 my $builder = Module::Build->new(%build_args);

--- a/Build.PL
+++ b/Build.PL
@@ -60,6 +60,11 @@ unless (`pkg-config --version` && $? == 0) {
   $build_args{'requires'}->{'PkgConfig'} = '0.07520';
 }
 
+# For now we prefer PkgConfig.pm over pkg-config on
+# Solaris 64 bit Perls.  We may need to do this on
+# other platforms, in which case this logic should
+# be abstracted so that it can be shared here and
+# in lib/Alien/Base.pm#pkg_config_command
 if($^O eq 'solaris' && $Config{ptrsize} == 8) {
   $build_args{'requires'}->{'PkgConfig'} = '0.08826';
 }

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -184,7 +184,7 @@ sub dist_dir {
       : $class->config('working_directory');
 
   croak "Failed to find share dir for dist '$dist'"
-    unless -d $dist_dir;
+    unless defined $dist_dir && -d $dist_dir;
 
   return $dist_dir;
 }

--- a/lib/Alien/Base/PkgConfig.pm
+++ b/lib/Alien/Base/PkgConfig.pm
@@ -124,6 +124,13 @@ my $pkg_config_command;
 sub pkg_config_command {
   unless (defined $pkg_config_command) {
     capture_stderr {
+    
+      # For now we prefer PkgConfig.pm over pkg-config on
+      # Solaris 64 bit Perls.  We may need to do this on
+      # other platforms, in which case this logic should
+      # be abstracted so that it can be shared here and
+      # in Build.PL
+
       if (`pkg-config --version` && $? == 0 && !($^O eq 'solaris' && $Config{ptrsize} == 8)) {
         $pkg_config_command = 'pkg-config';
       } else {

--- a/lib/Alien/Base/PkgConfig.pm
+++ b/lib/Alien/Base/PkgConfig.pm
@@ -7,6 +7,7 @@ our $VERSION = '0.012';
 $VERSION = eval $VERSION;
 
 use Carp;
+use Config;
 use File::Basename qw/fileparse/;
 use File::Spec;
 use Capture::Tiny qw( capture_stderr );
@@ -123,7 +124,7 @@ my $pkg_config_command;
 sub pkg_config_command {
   unless (defined $pkg_config_command) {
     capture_stderr {
-      if (`pkg-config --version` && $? == 0) {
+      if (`pkg-config --version` && $? == 0 && !($^O eq 'solaris' && $Config{ptrsize} == 8)) {
         $pkg_config_command = 'pkg-config';
       } else {
         require PkgConfig;


### PR DESCRIPTION
This will prefer PkgConfig.pm on 64 bit Solaris Perls.

The problem with 64 bit Solaris (I believe AIX and HP-UX are similar) is that it is a dual 32/64 bit system where most of the tools are actually 32 bit and the default compiler output is 32 bit.  pkg-config does not come with Solaris by default, but if you do build it from source it will point to 32 bit libs and header files. `PkgConfig.pm` (as of version 0.08826) looks in the correct `lib/pkgconfig` directories if it is invoked by a 64 bit Perl.  This is a reasonable default.

If the end user needs explicit control over which directories to search for `.pc` files he/she can still set `PKG_CONFIG_PATH` or `PKG_CONFIG_LIBPATH`.

This does not resolve the problem of building libs from source, which is a thornier issue. 