### PR TITLE
Don't Panic when install gets relocated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ script:
   - ./Build
   - prove -bv t
   - ./Build install
+  - cd Alien-Base-Extras/Acme-Alien-DontPanic; cpanm -l /tmp/original -v .
+  - mv /tmp/original /tmp/moved
+  - cd Alien-Base-Extras/Acme-Ford-Prefect;    cpanm -l /tmp/moved -v .
   - cd Alien-Base-Extras/Acme-Alien-DontPanic; cpanm --installdeps . && perl Build.PL && ./Build && ./Build test && ./Build install
   - cd Alien-Base-Extras/Acme-Ford-Prefect;    cpanm --installdeps . && perl Build.PL && ./Build && ./Build test && ./Build install
   - cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ script:
   - ./Build install
   - cd Alien-Base-Extras/Acme-Alien-DontPanic; cpanm -l /tmp/original -v .
   - mv /tmp/original /tmp/moved
-  - cd Alien-Base-Extras/Acme-Ford-Prefect;    cpanm -l /tmp/moved -v .
-  - cd Alien-Base-Extras/Acme-Alien-DontPanic; cpanm --installdeps . && perl Build.PL && ./Build && ./Build test && ./Build install
-  - cd Alien-Base-Extras/Acme-Ford-Prefect;    cpanm --installdeps . && perl Build.PL && ./Build && ./Build test && ./Build install
+  - cd ../../Alien-Base-Extras/Acme-Ford-Prefect;    cpanm -l /tmp/moved -v .
+  - cd ../../Alien-Base-Extras/Acme-Alien-DontPanic; cpanm --installdeps . && perl Build.PL && ./Build && ./Build test && ./Build install
+  - cd ../../Alien-Base-Extras/Acme-Ford-Prefect;    cpanm --installdeps . && perl Build.PL && ./Build && ./Build test && ./Build install
   - cd ../..
   - prove -bv t
 

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -287,6 +287,16 @@ sub _keyword {
     ) }
     @pc;
 
+  if($self->config('original_prefix') ne $self->dist_dir)
+  {
+    my $old = quotemeta $self->config('original_prefix');
+    @strings = map {
+      s{^(-I|-L|-LIBPATH:)?($old)}{$1.$self->dist_dir}e;
+      s/(\s)/\\$1/g;
+      $_;
+    } map { $self->split_flags($_) } @strings;
+  }
+
   return join( ' ', @strings );
 }
 

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -287,7 +287,7 @@ sub _keyword {
     ) }
     @pc;
 
-  if($self->config('original_prefix') ne $self->dist_dir)
+  if(defined $self->config('original_prefix') && $self->config('original_prefix') ne $self->dist_dir)
   {
     my $old = quotemeta $self->config('original_prefix');
     @strings = map {

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -439,7 +439,7 @@ sub ACTION_alien_install {
     foreach my $dir (qw( bin lib )) {
       next unless -d $dir;
       opendir(my $dh, $dir);
-      my @dlls = grep { /\.so/ || /\.(dylib|la|dll|dll\.a)$/ } grep !/^\./, readdir $dh;
+      my @dlls = grep { /\.so/ || /\.(dylib|bundle|la|dll|dll\.a)$/ } grep !/^\./, readdir $dh;
       closedir $dh;
       foreach my $dll (@dlls) {
         my $from = File::Spec->catfile($dir, $dll);

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -346,6 +346,7 @@ sub ACTION_alien_code {
   }
 
   $self->config_data( install_type => 'share' );
+  $self->config_data( original_prefix => $self->alien_library_destination );
 
   my $pc = $self->alien_load_pkgconfig;
   my $pc_version = (


### PR DESCRIPTION
This updates the `-L` and `-I` flags to the correct paths when the share dir gets relocated, something that is supported by recent Perls.  My first attempt at this (see branch "movable" if interested) was to provide a `%s` placeholder in the ConfigData and expand it in `Alien::Base`, but this seemed unnecessarily complicated (Also the implementation is incomplete).

It should also handle a weird corner case when Perl is configured to install modules to a different directory form where modules get used.  This is the default for AFS.  It is also the case at `$work` where the SAs have a mildly idiotic install procedure for perl modules.

This kind of thing is tricky to test from `Test::More`, so I opted to add a test in the `.travis.yml` by installing with `cpanm` and the `-l` flag.

I noticed while I was in there that we hadn't been testing `Acme::Ford::Prefect` from this `.travis.yml` (it does get tested in the `Alien-Base-Extras`'s `.travis.yml`).  I can't say for sure, but I think the travis semantics have changed in a subtle way, because I am pretty sure I checked the output when I came up with the older version of the `.travis.yml`, and I did it the way I did it on purpose.  Anyhow, I have fixed that while I was at it.