### PR TITLE
.t files are not Perl 6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.t linguist-language=Perl


### PR DESCRIPTION
This should fix the statistics for the project so that .t files are not incorrectly listed as Perl 6 code.  I found the directions for this here:

https://github.com/github/linguist#overrides

Not really the most pressing issue, but I like to represent Perl 5 :)