### PR TITLE
stage install to blib when building PPM files for ActiveState

### DIFF
--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -180,6 +180,15 @@ Hash reference of modules (keys) and versions (values) that specifies C<Alien> m
 
 These only become required for building if L<Alien::Base::ModuleBuild> determines that a source code build is required.
 
+=item alien_stage_install
+
+[version 0.016]
+
+Alien packages that should be installed directory into the blib directory by the `./Build' command rather than to the final location during the `./Build install` step.
+
+This is the default when building an ActiveState PPM package because AS does not do `./Build install'.
+
+
 =back
 
 =head2 PACKAGE AND ENVIRONMENT VARIABLES


### PR DESCRIPTION
This should resolve the issue raised in this comment:

https://github.com/Perl5-Alien/Alien-Base/issues/94#issuecomment-76234928

Problem is that ActiveState Perl when constructing ppm files uses just the files in `blib`.  They do not, in fact, run `./Build install` at all.  Happily a PPM build can be detected through an environment variable.

Instead of installing to the final location during the `./Build install` we install to the staged share directory during the `./Build` step for ActiveState installs ONLY, or if the AB subclass requests it.  I plan on using this feature for `Alien::FFI` even for non AS installs.

In addition, this PR would resolve #94 completely if made the default, which I think we should consider, but is not included in this patch.  We can discuss making this a default option on #94 as needed, but I would like to see at least this get merged as soon as possible.