### PR TITLE
OS X dylib relocation

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -670,6 +670,10 @@ sub _env_do_system {
     local $CWD;
     pop @CWD;
     
+    my $ldflags = $Config{ldflags};
+    $ldflags .= " -Wl,-headerpad_max_install_names"
+      if $^O eq 'darwin';
+    
     open my $fh, '>', 'config.site';
     print $fh "CC='$Config{cc}'\n";
     # -D define flags should be stripped because they are Perl
@@ -677,7 +681,7 @@ sub _env_do_system {
     print $fh "CFLAGS='", _filter_defines($Config{ccflags}), "'\n";
     print $fh "CPPFLAGS='", _filter_defines($Config{cppflags}), "'\n";
     print $fh "CXXFLAGS='", _filter_defines($Config{ccflags}), "'\n";
-    print $fh "LDFLAGS='$Config{ldflags}'\n";
+    print $fh "LDFLAGS='$ldflags'\n";
     close $fh;
   
     my $config ||= _shell_config_generate();

--- a/t/builder.t
+++ b/t/builder.t
@@ -3,6 +3,8 @@ use warnings;
 
 use Test::More;
 
+BEGIN { delete $ENV{ACTIVESTATE_PPM_BUILD} }
+
 use Alien::Base::ModuleBuild;
 use File::chdir;
 use File::Temp ();


### PR DESCRIPTION
This addresses the dynamic library relocation issue mentioned by @jberger by correcting the .dylib file's id field.  I tested this with `Alien::Editline` and `Term::EditLine` by setting `alien_isoloate_dynamic` to `0`, and `alien_stage_install` to `1`.  This allowed me to reproduce the problem, and correct it. 