### PR TITLE
Patch download and extraction of absolute HTTP URIs

### DIFF
--- a/lib/Alien/Base/ModuleBuild/File.pm
+++ b/lib/Alien/Base/ModuleBuild/File.pm
@@ -33,13 +33,12 @@ sub get {
   ## whatever happened, record the new filename
   $self->{filename} = $filename;
 
-
   if (defined $self->{sha1} || defined $self->{sha256}) {
     unless (eval 'require Digest::SHA') {
       warn "sha1 or sha256 sums are specified but cannot be checked since Digest::SHA is not installed";
       return $filename;
     }
-  
+
     eval 'require Digest::SHA' or return $filename;
     ## verify that the SHA-1 and/or SHA-256 sums match if provided
     if (defined $self->{sha1}) {
@@ -62,7 +61,7 @@ sub get {
     }
   }
 
-  return $self->filename;
+  return $filename;
 }
 
 sub platform   { shift->{platform}   }

--- a/lib/Alien/Base/ModuleBuild/File.pm
+++ b/lib/Alien/Base/ModuleBuild/File.pm
@@ -27,8 +27,11 @@ sub get {
 
   my $filename = $repo->get_file($self->filename);
   if ( my $new_filename = $repo->{new_filename} ) {
-    $filename = $self->{filename} = $new_filename;
+    $filename = $new_filename;
   }
+
+  ## whatever happened, record the new filename
+  $self->{filename} = $filename;
 
 
   if (defined $self->{sha1} || defined $self->{sha256}) {

--- a/t/http.t
+++ b/t/http.t
@@ -138,5 +138,35 @@ subtest 'get_file()' => sub {
   };
 };
 
+subtest 'get()' => sub {
+  subtest 'mock client' => sub {
+    my $repo = Alien::Base::ModuleBuild::Repository::HTTP->new(
+      protocol_class => 'Test::Alien::Base::HTTP',
+    );
+    my $file = Alien::Base::ModuleBuild::File->new(
+      repository => $repo,
+      filename => 'http://example.com/test.tar.gz',
+    );
+    my $filename = $file->get();
+    is $filename, 'test.tar.gz';
+  };
+  subtest 'LWP::UserAgent' => sub {
+    plan skip_all => 'No LWP::UserAgent' unless eval { require LWP::UserAgent; 1 };
+    my $repo = Alien::Base::ModuleBuild::Repository::HTTP->new(
+      protocol_class => 'LWP::UserAgent',
+    );
+    # Change to a tempdir so our file gets automatically cleaned up
+    my $tmp = File::Temp->newdir;
+    local $CWD = $tmp->dirname;
+
+    my $file = Alien::Base::ModuleBuild::File->new(
+      repository => $repo,
+      filename => URI::file->new($INDEX_PATH)->as_string,
+    );
+    my $filename = $file->get();
+    is $filename, 'index.html';
+  };
+};
+
 done_testing;
 


### PR DESCRIPTION
Real-world fetching of an absolute HTTP URI (as you find with zlib for example) leads to an error because the expander is passed the URI instead of the bare name of the downloaded file:
* the patch to t/http.t shows this problem
* the patch to  lib/Alien/Base/ModuleBuild/File.pm solves the problem

The third commit is an optional cosmetic change that tidies get() up a bit. In particular, the return value at the end has been changed to make it consistent with the return at line 39.

Thanks a lot for Alien::Base!!!