### PR TITLE
make a staged install the default

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -127,11 +127,8 @@ __PACKAGE__->add_property( 'alien_msys' => 0 );
 # Alien packages that provide build dependencies
 __PACKAGE__->add_property( 'alien_bin_requires' => {} );
 
-# Alien packages that can/should be installed directory into the blib directory by the `./Build' command
-# rather than to the final location during the `./Build install` step.
-# This is the default when building an ACTIVESTATE_PPM_BUILD because AS does not do `./Build install` at
-# all when building a PPM
-__PACKAGE__->add_property( 'alien_stage_install' => $ENV{ACTIVESTATE_PPM_BUILD} ? 1 : 0 );
+# Do a staged install to blib instead of trying to install to the final location.
+__PACKAGE__->add_property( 'alien_stage_install' => 1 );
 
 ################
 #  ConfigData  #

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -186,8 +186,9 @@ These only become required for building if L<Alien::Base::ModuleBuild> determine
 
 Alien packages are installed directly into the blib directory by the `./Build' command rather than to the final location during the `./Build install` step.
 
-This is the default when building an ActiveState PPM package because AS does not do `./Build install'.
+[version 0.017]
 
+As of 0.017 this is the default.
 
 =back
 


### PR DESCRIPTION
As alluded to in #94 and #114 I would like to make `alien_stage_install=1` be the default behavior.  The main motivation for this is to make cpan testers work the same way as a regular install.  This would, in my opinion, fix #94.  The main reason not to do this up until now is that relocation weren't supported, especially on OS X.  With the inclusion of #115 this does not appear to be a problem anymore.

Although I do not think this change should have an effect on most `Alien::Base` based distributions, this is a change in behavior, and I propose this conservative approach to deployment:

 * 0.016 goes out as planned with what is in master right now (d013789f1d79d72319c634d322efedc5d3ab8902 more or less)
 * once that has been released to CPAN, I will post to blogs.perl.org announcing the change and describing the pittfalls to `Alien::Base` based distributions.
 * release 0.016_01 dev release with the changes in this branch so that developers can test what they have read about in the above blog entry
 * I will proactively go through the `Alien::Base` distributions to see if there are any distributions that need fixing, focusing on dists that are actually used by other dists (I did then when preparing for the 0.005 release).
 * I will also change some of my `Alien::Base` dists to explicitly use `alien_stage_install=1` so that we can get some feedback from cpantesters.
 * wait a few weeks, I propose 4.
 * release 0.017 with `alien_stage_install=1` as the default
 * (optional) after some time if it seems as though the old behavior is unnecessary, we can mark it as deprecated
 * (optional) after some more time remove old deprecated behavior as an option to make maintenance easier.