### PR TITLE
Install into architecture specific directory by default

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -134,7 +134,8 @@ __PACKAGE__->add_property( 'alien_stage_install' => 1 );
 # Most alien dists will have arch specific files in their share so it makes sense to install
 # the module in the arch specific location.  If you are alienizing something that isn't arch
 # specific, like javascript source or java byte code, then you'd want to set this to 0.
-__PACKAGE__->add_property( 'alien_arch' => defined $ENV{ALIEN_ARCH} ? $ENV{ALIEN_ARCH} : 1 );
+# For now this will default to off.  See gh#119 for a discussion.
+__PACKAGE__->add_property( 'alien_arch' => defined $ENV{ALIEN_ARCH} ? $ENV{ALIEN_ARCH} : 0 );
 
 ################
 #  ConfigData  #

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -134,7 +134,7 @@ __PACKAGE__->add_property( 'alien_stage_install' => 1 );
 # Most alien dists will have arch specific files in their share so it makes sense to install
 # the module in the arch specific location.  If you are alienizing something that isn't arch
 # specific, like javascript source or java byte code, then you'd want to set this to 0.
-__PACKAGE__->add_property( 'alien_arch' => 1 );
+__PACKAGE__->add_property( 'alien_arch' => defined $ENV{ALIEN_ARCH} ? $ENV{ALIEN_ARCH} : 1 );
 
 ################
 #  ConfigData  #

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -593,7 +593,7 @@ sub alien_library_destination {
   my $lib_dir = 
     $self->notes('alien_blib_scheme') || $self->alien_stage_install
     ? File::Spec->catdir( $self->base_dir, $self->blib, 'lib' )
-    : $self->install_destination('lib');
+    : $self->install_destination($self->alien_arch ? 'arch' : 'lib');
 
   my $dist_name = $self->dist_name;
   my $dest = _catdir( $lib_dir, qw/auto share dist/, $dist_name );
@@ -1042,7 +1042,7 @@ sub alien_relocation_fixup {
   return unless $^O eq 'darwin';
 
   my $dist_name = $self->dist_name;  
-  my $share = _catdir( $self->install_destination('lib'), qw/auto share dist/, $dist_name );
+  my $share = _catdir( $self->install_destination($self->alien_arch ? 'arch' : 'lib'), qw/auto share dist/, $dist_name );
   
   require File::Find;
   File::Find::find(sub {

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -220,6 +220,14 @@ Setting either to a true value will cause the builder to ignore a system-wide in
 
 Setting this to true indicates that you don't intend to actually install your Alien::Base subclass, but rather use it from the built F<blib> directory. This behavior is mostly to support automated testing from CPANtesters and should be automagically determined. If by chance you happen to trip the behavior accidentally, setting this environment variable to false (0) before building should prevent problems. 
 
+=item $ENV{ALIEN_ARCH}
+
+[version 0.017]
+
+Setting this changes the default for alien_arch above.  If the module specifies its own alien_arch in its C<Build.PL> file then it will override this setting.  Typically installing into an architecture specific directory is what you
+want to do, since most L<Alien::Base> based distributions provide architecture specific binary code, so you should consider carefully before installing modules with this environment variable set to 0.  This may be useful for
+integrators creating a single non-architecture specific RPM, .dep or similar package.  In this case the integrator should ensure that the Alien package be installed with a system install_type and use the system package.
+
 =back
 
 =head2 CONFIG DATA

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -192,9 +192,9 @@ As of 0.017 this is the default.
 
 =item alien_arch
 
-[version 0.017]
+[version 0.019]
 
-Install module into an architecture specific directory.  This is the default, as most Alien distributions will be installing binary code.  If you are installing something not architecture specific, like JavaScript or Java byte code, then you should set this to 0.
+Install module into an architecture specific directory.  This is off by default, unless $ENV{ALIEN_ARCH} is true.  Most Alien distributions will be installing binary code.  If you are an integrator where the C<@INC> path is shared by multiple Perls in a non-homogeneous environment you can set $ENV{ALIEN_ARCH} to 1 and Alien modules will be installed in architecture specific directories.
 
 =back
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -190,6 +190,12 @@ Alien packages are installed directly into the blib directory by the `./Build' c
 
 As of 0.017 this is the default.
 
+=item alien_arch
+
+[version 0.017]
+
+Install module into an architecture specific directory.  This is the default, as most Alien distributions will be installing binary code.  If you are installing something not architecture specific, like JavaScript or Java byte code, then you should set this to 0.
+
 =back
 
 =head2 PACKAGE AND ENVIRONMENT VARIABLES

--- a/t/builder.t
+++ b/t/builder.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-BEGIN { delete $ENV{ACTIVESTATE_PPM_BUILD} }
+BEGIN { delete $ENV{ACTIVESTATE_PPM_BUILD}; $ENV{ALIEN_ARCH} = 0 }
 
 use Alien::Base::ModuleBuild;
 use File::chdir;

--- a/t/builder.t
+++ b/t/builder.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-BEGIN { delete $ENV{ACTIVESTATE_PPM_BUILD}; $ENV{ALIEN_ARCH} = 0 }
+BEGIN { delete $ENV{ACTIVESTATE_PPM_BUILD} }
 
 use Alien::Base::ModuleBuild;
 use File::chdir;


### PR DESCRIPTION
This would allow the same lib directory to be shared in a non-homogeneous network environment (see #118 for related discussion).  I have worked in these environments in the past, it is particularly useful with AFS.

Looking closely at the `Module::Build` and `ExtUtils::Install` source, the only way to force an install into the arch directory is if the blib/arch directory is not empty, so I propose putting a .txt file in there with the name of the module with a comment explaining its existence.

@jberger mentioned Mach as being an exception where you might want to install into a non-arch specific directory in a non-homogeneous environment.  The only example where mach is typically used with Perl that I could think of is OS X where the arch is the same for intel, ppc, 32 and 64 bit platforms, so even if Perl is a universal binary then thing should still work (things are not so good if you need to support multiple non-universal Perl binaries, but that is a problem for non-arch install as well).

One place I can think of where installing into the non-arch directory makes sense is for Linux distribution integrator who probably only want one Alien::Foo package, not one for each arch (assuming they package them correctly to use the system library), so I've provided them with an out.  If they set ALIEN_ARCH=0 this will override the *default* value for `alien_arch`.

I'd be interested in any other corner cases that anyone can think of.