### PR TITLE
Update config data

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -466,7 +466,7 @@ sub ACTION_alien_install {
   $self->config_data( 'finished_installing' => 1 );
 
   # to refresh config_data
-  $self->SUPER::ACTION_config_data;
+  $self->alien_force_update_config_data;
 
   if ( $self->notes( 'alien_blib_scheme') || $self->alien_stage_install) {
     # reinstall config_data to blib
@@ -479,6 +479,16 @@ sub ACTION_alien_install {
     # refresh the packlist
     $self->alien_refresh_packlist( $self->alien_library_destination );
   }
+}
+
+sub alien_force_update_config_data
+{
+  my($self) = @_;
+  my $module_name = $self->module_name;
+  my $config_name = $module_name . '::ConfigData';
+  my $config_pm   = File::Spec->catfile($self->blib, 'lib', split /::/, "$config_name.pm");
+  unlink $config_pm;
+  $self->ACTION_config_data;
 }
 
 #######################

--- a/t/inline.t
+++ b/t/inline.t
@@ -4,7 +4,7 @@ use Test::More;
 
 BEGIN {
   eval q{ use Inline 0.56 (); require Inline::C; } || plan skip_all => 'test requires Inline 0.56 and Inline::C';
-  eval q{ use Acme::Alien::DontPanic 0.010; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.010 :' . $@;
+  eval q{ use Acme::Alien::DontPanic 0.022; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.022 :' . $@;
   plan skip_all => 'test requires that Acme::Alien::DontPanic was build with Alien::Base 0.006'
     unless defined Acme::Alien::DontPanic->Inline("C")->{AUTO_INCLUDE};
 }

--- a/t/inline_cpp.t
+++ b/t/inline_cpp.t
@@ -4,7 +4,7 @@ use Test::More;
 
 BEGIN {
   eval q{ use Inline 0.56 (); require Inline::CPP; } || plan skip_all => 'test requires Inline 0.56 and Inline::CPP';
-  eval q{ use Acme::Alien::DontPanic 0.010; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.010 :' . $@;
+  eval q{ use Acme::Alien::DontPanic 0.022; 1 } || plan skip_all => 'test requires Acme::Alien::DontPanic 0.022 :' . $@;
   plan skip_all => 'test requires that Acme::Alien::DontPanic was build with Alien::Base 0.006'
     unless defined Acme::Alien::DontPanic->Inline("CPP")->{AUTO_INCLUDE};
 }


### PR DESCRIPTION
This fixes an existing bug in AB that was revealed by the new install into blib strategy (the same thing can happen with a blib cpan testers install, but it is not as critical there).  The problem is that even though _build/config_data is updated, it has the same timestamp as ConfigData.pm.  To work around this I remove the ConfigData.pm file and call ACTION_config_data.  I am happy to entertain alternate solutions, this is kind of a hack, but would like to resolve this quickly.

The manifestation of this bug is that finished_installing will not be set correctly.  dist_dir and clfags and libs may be incorrect as a result.  Acme::Alien::DontPanic 0.021 is tainted, so the inline tests will require 0.022.