### PR TITLE
all ACTION_alien_install from process_share_dir_files when installing to blib

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -260,9 +260,6 @@ sub ACTION_code {
 
     $self->depends_on('alien_code');
     $self->SUPER::ACTION_code;
-
-    # copy the compiled files into blib if running under blib scheme
-    $self->depends_on('alien_install') if $self->notes('alien_blib_scheme') || $self->alien_stage_install;
   }
   
   my $module = $self->module_name;
@@ -286,6 +283,14 @@ sub Inline { shift; $module->Inline(\@_) }
 EOF
     close $fh;
   }
+}
+
+sub process_share_dir_files {
+  my $self = shift;
+  $self->SUPER::process_share_dir_files(@_);
+  
+  # copy the compiled files into blib if running under blib scheme
+  $self->depends_on('alien_install') if $self->notes('alien_blib_scheme') || $self->alien_stage_install;
 }
 
 sub ACTION_alien_code {
@@ -465,14 +470,15 @@ sub ACTION_alien_install {
   $self->alien_refresh_manual_pkgconfig( $self->alien_library_destination );
   $self->config_data( 'finished_installing' => 1 );
 
-  # to refresh config_data
-  $self->SUPER::ACTION_config_data;
-
   if ( $self->notes( 'alien_blib_scheme') || $self->alien_stage_install) {
-    # reinstall config_data to blib
-    $self->process_files_by_extension('pm');
+    ## reinstall config_data to blib
+    #$self->process_files_by_extension('pm');
 
   } else {
+
+    # to refresh config_data
+    $self->SUPER::ACTION_config_data;
+
     # reinstall config_data
     $self->SUPER::ACTION_install;
 

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -471,6 +471,10 @@ sub ACTION_alien_install {
   $self->config_data( 'finished_installing' => 1 );
 
   if ( $self->notes( 'alien_blib_scheme') || $self->alien_stage_install) {
+  
+    ### TODO: empty if should be claned up before 0.017.
+    ### we used to call process_files_by_extension('pm')
+    ### here, but with gh#121 it is unecessary
     ## reinstall config_data to blib
     #$self->process_files_by_extension('pm');
 


### PR DESCRIPTION
This is an alternate solution for #120, which I now mildly prefer.

For a blib install (either cpan testers or alien_stage_install) it does the actual `ACTION_alien_install` inside the `process_share_dir_files`, which ensures that the config data is updated BEFORE `ACTION_config_data` is called, thus negating the need to force the update of ConfigData.pm.

This fixes a bug that has existed for a long time but is exposed in a critical manner on CPAN as of 0.016, so a fast resolution would be highly desirable.