### PR TITLE
Add IRC info to meta and documentation

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -53,7 +53,7 @@ my %build_args = (
       file      => [ 'README.pod' ],
       directory => [ 'examples', 't' ],
     },
-    "x_IRC" : "irc://irc.perl.org/#alien"
+    "x_IRC" : "irc://irc.perl.org/#native"
   },
 );
 

--- a/Build.PL
+++ b/Build.PL
@@ -53,6 +53,7 @@ my %build_args = (
       file      => [ 'README.pod' ],
       directory => [ 'examples', 't' ],
     },
+    "x_IRC" : "irc://irc.perl.org/#alien"
   },
 );
 

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -496,9 +496,9 @@ __POD__
 
 =head1 SUPPORT AND CONTRIBUTING
 
-IRC: #alien on irc.perl.org
+IRC: #native on irc.perl.org
 
- L<(click for instant chatroom login)|http://chat.mibbit.com/#alien@irc.perl.org> 
+ L<(click for instant chatroom login)|http://chat.mibbit.com/#native@irc.perl.org> 
 
 If you find a bug, please report it on the projects issue tracker on GitHub:
 

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -496,6 +496,10 @@ __POD__
 
 =head1 SUPPORT AND CONTRIBUTING
 
+IRC: #alien on irc.perl.org
+
+ L<(click for instant chatroom login)|http://chat.mibbit.com/#alien@irc.perl.org> 
+
 If you find a bug, please report it on the projects issue tracker on GitHub:
 
 =over 4


### PR DESCRIPTION
I propose that we advertise the IRC channel #alien for all things `Alien` and `Alien::Base`.  We discussed having a place on IRC back when we created the mailing list, but since I wasn't on IRC and nobody else seemed keen, we didn't do it at that time.  At YAPC::NA @felliott pointed out to me that there was a (very quiet) #alien and I've come around to the idea that it is a good way to interact for quick questions where opening an issue or PR is not appropriate.  Plus with the meta change metacpan users get a big red button that they can click on for support.  I believe @jberger and @zmughal are on this channel and I am set up now to be there at least part time as well, though I am an IRC noob.

Since there does seem to some overlap @felliott suggested using this for FFI / Platypus as well.  If you have any objections to that then please register them when voting on this PR.  Also suggestions for an alternate common IRC channel name would be appropriate.  Also feel free to logon to the IRC itself and discuss there :)