### PR TITLE
interpolation of arbitrary perl at command time

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -26,6 +26,7 @@ use Shell::Config::Generate;
 use File::Path qw/mkpath/;
 use Config;
 use Text::ParseWords qw( shellwords );
+use Text::Balanced qw( extract_bracketed );
 
 use Alien::Base::PkgConfig;
 use Alien::Base::ModuleBuild::Cabinet;
@@ -828,6 +829,16 @@ sub alien_interpolate {
     } else {
       $string =~ s/(?<!\%)\%v/$version/g;
     }
+
+  }
+
+  while($string =~ s/(?<!\%)\%(\{.*)$//) {
+    my($perl, $rest) = extract_bracketed "$1", '{}';
+    my $value = eval qq{
+      package Alien::Base::ModuleBuild::Sandbox;
+      $perl
+    };
+    $string .= $value . $rest;
   }
 
   #remove escapes (%%)

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -807,6 +807,8 @@ sub alien_interpolate {
   my $share  = $self->alien_library_destination;
   my $name   = $self->alien_name || '';
 
+  my $original = $string;
+
   # substitute:
   #   install location share_dir (placeholder: %s)
   $string =~ s/(?<!\%)\%s/$share/g;
@@ -834,10 +836,13 @@ sub alien_interpolate {
 
   while($string =~ s/(?<!\%)\%(\{.*)$//) {
     my($perl, $rest) = extract_bracketed "$1", '{}';
+    die "unable to extract Perl block for interpolation from '$original'"
+      unless defined $perl;
     my $value = eval qq{
       package Alien::Base::ModuleBuild::Sandbox;
       $perl
     };
+    die $@ if $@;
     $string .= $value . $rest;
   }
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -266,6 +266,10 @@ Before L<Alien::Base::ModuleBuild> executes system commands, it replaces a few s
 
 =over
 
+=item %{ I<arbitrary perl code> }
+
+The Perl code inside the curly braces will be evaluated and the result will be interpolated immediately before the command is executed.  Nested curly braces will be handled correctly.
+
 =item %s
 
 The full path to the final installed location of the share directory (builder method C<alien_library_destination>). This is where the library should install itself; for autoconf style installs this will look like 

--- a/t/interpolate.t
+++ b/t/interpolate.t
@@ -55,6 +55,7 @@ is( $builder->alien_interpolate('%x'), $perl, '%x is current interpreter' );
 
 is $builder->alien_interpolate('| %{ "foo" . "bar" } |'), '| foobar |', 'interpolation of arbitrary perl';
 is $builder->alien_interpolate('| %{ join ",", map { $_ - 1 } 2..11 } |'), '| 1,2,3,4,5,6,7,8,9,10 |', 'interpolation of arbitrary perl with nested brackets';
+is $builder->alien_interpolate('| %{ "foo" } %{ "bar" } |'), '| foo bar |', 'interpolation of arbitrary perl, multiple times';
 
 eval { $builder->alien_interpolate('| %{ ') };
 like $@, qr{unable to extract Perl block for interpolation from}, 'interpolation of arbitrary perl bad extract';

--- a/t/interpolate.t
+++ b/t/interpolate.t
@@ -53,6 +53,9 @@ is( $builder->alien_interpolate('%x'), $perl, '%x is current interpreter' );
   is( join( "\n", @warn ),                       '',                      'version warning after setting it' );
 }
 
+is $builder->alien_interpolate('| %{ "foo" . "bar" } |'), '| foobar |', 'interpolation of arbitrary perl';
+is $builder->alien_interpolate('| %{ join ",", map { $_ - 1 } 2..11 } |'), '| 1,2,3,4,5,6,7,8,9,10 |', 'interpolation of arbitrary perl with nested brackets';
+
 done_testing;
 
 package

--- a/t/interpolate.t
+++ b/t/interpolate.t
@@ -56,6 +56,13 @@ is( $builder->alien_interpolate('%x'), $perl, '%x is current interpreter' );
 is $builder->alien_interpolate('| %{ "foo" . "bar" } |'), '| foobar |', 'interpolation of arbitrary perl';
 is $builder->alien_interpolate('| %{ join ",", map { $_ - 1 } 2..11 } |'), '| 1,2,3,4,5,6,7,8,9,10 |', 'interpolation of arbitrary perl with nested brackets';
 
+eval { $builder->alien_interpolate('| %{ ') };
+like $@, qr{unable to extract Perl block for interpolation from}, 'interpolation of arbitrary perl bad extract';
+note $@;
+
+eval { $builder->alien_interpolate('| %{ die "foobarbaz" } |') };
+like $@, qr{foobarbaz}, 'interpolation of arbitrary exception';
+
 done_testing;
 
 package


### PR DESCRIPTION
As discussed on IRC this allows the interpolation of arbitrary Perl at build and staged install time.  It would simplify a number of the solutions in the FAQ branch, which I intend on updating if this is accepted.  This handles nested `{ { } }`.  I've never used `Text::Balanced` before so if let me know if I'm doing something terribly wrongly.