### PR TITLE
interpolate helpers

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -460,7 +460,7 @@ sub bin_dir {
  my $helpers = Alien::MyLibrary->alien_helper;
 
 Returns a hash reference of helpers provided by the Alien module.
-They keys are helper names and the values are code references.  The
+The keys are helper names and the values are code references.  The
 code references will be executed at command time and the return value
 will be interpolated into the command before execution.  The default
 implementation returns an empty hash reference, and you are expected

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -466,6 +466,12 @@ will be interpolated into the command before execution.  The default
 implementation returns an empty hash reference, and you are expected
 to override the method to create your own helpers.
 
+For compatability with the C<Alien::Base::ModuleBuild> attribute C<alien_helper>,
+helpers may also be specified as Perl strings that will be evaluated
+and executed at command time.  This is necessary because of limitations
+with C<Module::Build>, and you are strongly encouraged to use code
+references when defining helpers from an Alien module.
+
 Helpers allow users of your Alien module to use platform or environment 
 determined logic to compute command names or arguments in 
 C<alien_build_commands> or C<alien_install_commands> in their C<Build.PL>.

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -242,6 +242,9 @@ END
 sub ACTION_alien_fakebuild {
   my $self = shift;
 
+  # needed for any helpers provided by alien_bin_requires
+  $self->_alien_bin_require($_) for keys %{ $self->alien_bin_requires };
+
   print "# Build\n";
   foreach my $cmd (@{ $self->alien_build_commands })
   {

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -662,6 +662,7 @@ sub _alien_bin_require {
   if($mod->can('alien_helper')) {
     my $helpers = $mod->alien_helper;
     while(my($k,$v) = each %$helpers) {
+      next if defined $self->alien_helper->{$k};
       $self->alien_helper->{$k} = $v;
     }
   }

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -196,6 +196,12 @@ As of 0.017 this is the default.
 
 Install module into an architecture specific directory.  This is off by default, unless $ENV{ALIEN_ARCH} is true.  Most Alien distributions will be installing binary code.  If you are an integrator where the C<@INC> path is shared by multiple Perls in a non-homogeneous environment you can set $ENV{ALIEN_ARCH} to 1 and Alien modules will be installed in architecture specific directories.
 
+=item alien_helper
+
+[version 0.020]
+
+Provide helpers to be used in commands.  TODO
+
 =back
 
 =head2 PACKAGE AND ENVIRONMENT VARIABLES
@@ -265,6 +271,12 @@ Holder for C<alien_name> as needed by pkg-config.
 Before L<Alien::Base::ModuleBuild> executes system commands, it replaces a few special escape sequences with useful data. This is needed especially for referencing the full path to the C<alien_share_dir> before this path is known. The availble sequences are:
 
 =over
+
+=item %{I<helper>}
+
+[version 0.020]
+
+Call the given helper, either provided by the C<alien_helper> or C<alien_bin_requires> property. TODO
 
 =item %s
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -200,7 +200,27 @@ Install module into an architecture specific directory.  This is off by default,
 
 [version 0.020]
 
-Provide helpers to be used in commands.  TODO
+Provide helpers to generate commands or arguments at build or install time.  This property is a hash 
+reference.  The keys are the helper names and the values are strings containing Perl code that will 
+be evaluated and interpolated into the command before execution.  Because helpers are only needed 
+when building a package from the source code, any dependency may be specified as an 
+C<alien_bin_requires>.  For example:
+
+ ...
+ Alien::Base::ModuleBuild->new(
+   ...
+   alien_bin_requires => {
+     'Alien::foo' => 0,
+   },
+   alien_helper => {
+     'foocommand'  => 'Alien::foo->some_command',
+     'fooargument' => 'Alien::foo->some_argument',
+   },
+   alien_build_commands => [
+     '%{foocommand} %{fooargument}',
+   ],
+   ...
+ );
 
 =back
 
@@ -276,7 +296,7 @@ Before L<Alien::Base::ModuleBuild> executes system commands, it replaces a few s
 
 [version 0.020]
 
-Call the given helper, either provided by the C<alien_helper> or C<alien_bin_requires> property. TODO
+Call the given helper, either provided by the C<alien_helper> or C<alien_bin_requires> property.  See L<Alien::Base#alien_helper>.
 
 =item %s
 

--- a/t/interpolate.t
+++ b/t/interpolate.t
@@ -11,6 +11,7 @@ my $builder = Alien::Base::ModuleBuild->new(
   alien_helper => {
     foo => ' "bar" . "baz" ',
     exception => ' die "abcd" ',
+    double => '"1";',
   },
   alien_bin_requires => {
     'Alien::foopatcher' => 0,
@@ -72,6 +73,8 @@ is( $builder->alien_interpolate("|%{patch2}|"), "|patch2 --binary|", "helper fro
 eval { $builder->alien_interpolate("%{bogus}") };
 like $@, qr{no such helper: bogus}, "exception thrown with bogus helper";
 
+is( $builder->alien_interpolate('%{double}'), "1", "MB helper overrides AB helper");
+
 done_testing;
 
 package
@@ -89,5 +92,6 @@ sub alien_helper {
     return {
       patch1 => 'join " ", qw(patch1 --binary)',
       patch2 => sub { 'patch2 --binary' },
+      double => sub { 2 },
     },
 }


### PR DESCRIPTION
Here is an alternative to #129 based on suggestions made by @shadowcat-mst

Helpers can be strings of Perl code (in `Build.PL`) or code references (from `Alien::foo`).  To define helpers from an Alien module (does not need to be based on AB), simply return a hashref of helpers from a sub named `alien_helper`.