### PR TITLE
honor alien_provides_* on system install

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -271,7 +271,10 @@ sub _keyword {
 
     $! = 0;
     chomp ( my $pcdata = capture_merged { system( $command ) } );
-    croak "Could not call pkg-config: $!" if $!;
+
+    # if pkg-config fails for whatever reason, then we try to
+    # fallback on alien_provides_*
+    $pcdata = '' if $! || $?;
 
     $pcdata =~ s/\s*$//;
 

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -275,6 +275,10 @@ sub _keyword {
 
     $pcdata =~ s/\s*$//;
 
+    if(my $system_provides = $self->config('system_provides')->{$keyword}) {
+      $pcdata = length $pcdata ? "$pcdata $system_provides" : $system_provides;
+    }
+
     return $pcdata;
   }
 

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -332,6 +332,12 @@ sub ACTION_alien_code {
   if ($version) {
     $self->config_data( install_type => 'system' );
     $self->config_data( version => $version );
+    my %system_provides;
+    $system_provides{Cflags} = $self->alien_provides_cflags
+      if defined $self->alien_provides_cflags;
+    $system_provides{Libs}   = $self->alien_provides_libs
+      if defined $self->alien_provides_libs;
+    $self->config_data( system_provides => \%system_provides );
     return;
   }
 

--- a/t/builder.t
+++ b/t/builder.t
@@ -372,6 +372,33 @@ subtest 'source build requires' => sub {
     my $builder = builder( alien_bin_requires => { 'Foo::Bar' => '1.1' } );
     is $builder->build_requires->{"Foo::Bar"}, '1.1', 'Foo::Bar = 1.1';
   };
+
+  rmtree [qw/ _alien  _share  blib  src /], 0, 0;
+};
+
+subtest 'system provides' => sub {
+
+  local $mb_class = do {
+    package My::MBBuildSystemProvidesExample;
+
+    use base qw( Alien::Base::ModuleBuild );
+
+    sub alien_check_installed_version {
+      return '1.0';
+    }
+
+    __PACKAGE__;
+  };
+
+  subtest 'not installed, not forced' => sub {
+    local $Alien::Base::ModuleBuild::Force = 0;
+    my $builder = builder( alien_provides_cflags => '-DMY_CFLAGS', alien_provides_libs => '-L/my/libs -lmylib' );
+    $builder->depends_on('code');
+    is $builder->config_data('system_provides')->{Cflags}, '-DMY_CFLAGS',          'cflags';
+    is $builder->config_data('system_provides')->{Libs},   '-L/my/libs -lmylib', 'libs';
+  };
+
+  rmtree [qw/ _alien  _share  blib  src /], 0, 0;
 };
 
 done_testing;


### PR DESCRIPTION
`alien_provides_cflags` and `alien_provides_libs` aren't honored currently when the library is provided by the system (either with or without pkg-config).  This PR will fix that.  I have a test for the builder itself.  I have tested this with 

https://github.com/plicease/Alien-Libbz2

To ensure that it also works once installed.  I will add that to the travis for AB so that we can catch any regressions there.