### PR TITLE
provide a %{pkg_cofig} by default

### DIFF
--- a/lib/Alien/Base/FAQ.pod
+++ b/lib/Alien/Base/FAQ.pod
@@ -17,6 +17,24 @@ to CPAN.  For a manifesto style description of the Why, and How see L<Alien>.  L
 class and framework for creating Alien distributions.  The idea is to address as many of the common challenges
 to developing Alien modules in the base class to simplify the process.
 
+=head2 How do I specify a minimum or exact version requirement for packages that use pkg-config?
+
+The C<alien_version_check> attribute to L<Alien::Base::ModuleBuild> will be executed to determine if
+the library is provided by the operating system.  The default for this is C<%{pkg_config} --modversion %n>
+which simply checks to see if any version of that package is available.
+
+ use Alien::Base::ModuleBuild;
+ Alien::Base::ModuleBuild->new(
+   dist_name           => 'Alien::Foo',
+   alien_name          => 'foo',
+   configure_requires  => { 'Alien::Base' => '0.021' }, # required for %{pkg_config}
+   alien_version_check => '%{pkg_config} --modversion %n --atleast-version 1.0.3',
+   ...
+ )->create_build_script;
+
+It is better to use the built in C<{%pkg_config}> helper as it will use the system provided pkg-config
+if it is available and fallback on the pure perl L<PkgConfig> if not.
+
 =head2 How to create an Alien module for packages that do not support pkg-config?
 
 Although L<Alien::Base> and L<Alien::Base::ModuleBuild> assume packages come with a C<pkg-config>

--- a/lib/Alien/Base/FAQ.pod
+++ b/lib/Alien/Base/FAQ.pod
@@ -27,7 +27,7 @@ which simply checks to see if any version of that package is available.
  Alien::Base::ModuleBuild->new(
    dist_name           => 'Alien::Foo',
    alien_name          => 'foo',
-   configure_requires  => { 'Alien::Base' => '0.021' }, # required for %{pkg_config}
+   configure_requires  => { 'Alien::Base' => '0.022' }, # required for %{pkg_config}
    alien_version_check => '%{pkg_config} --modversion %n --atleast-version 1.0.3',
    ...
  )->create_build_script;

--- a/lib/Alien/Base/FAQ.pod
+++ b/lib/Alien/Base/FAQ.pod
@@ -35,6 +35,8 @@ which simply checks to see if any version of that package is available.
 It is better to use the built in C<{%pkg_config}> helper as it will use the system provided pkg-config
 if it is available and fallback on the pure perl L<PkgConfig> if not.
 
+You can also use C<--exact-version> to specify an exact version.
+
 =head2 How to create an Alien module for packages that do not support pkg-config?
 
 Although L<Alien::Base> and L<Alien::Base::ModuleBuild> assume packages come with a C<pkg-config>

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -166,6 +166,9 @@ sub new {
 
   my $self = $class->SUPER::new(%args);
 
+  $self->alien_helper->{pkg_config} = 'Alien::Base::PkgConfig->pkg_config_command'
+    unless defined $self->alien_helper->{pkg_config};
+
   # setup additional temporary directories, and yes we have to add File::ShareDir manually
   $self->_add_prereq( 'requires', 'File::ShareDir', '1.00' );
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -222,7 +222,7 @@ C<alien_bin_requires>.  For example:
    ...
  );
 
-[version 0.021]
+[version 0.022]
 
 One helper that you get for free is C<%{pkg_config}> which will be the pkg-config implementation
 chosen by L<Alien::Base::ModuleBuild>.  This will either be the real pkg-config provided by the

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -222,6 +222,12 @@ C<alien_bin_requires>.  For example:
    ...
  );
 
+[version 0.021]
+
+One helper that you get for free is C<%{pkg_config}> which will be the pkg-config implementation
+chosen by L<Alien::Base::ModuleBuild>.  This will either be the real pkg-config provided by the
+operating system (preferred) or L<PkgConfig>, the pure perl implementation found on CPAN.
+
 =back
 
 =head2 PACKAGE AND ENVIRONMENT VARIABLES

--- a/t/interpolate.t
+++ b/t/interpolate.t
@@ -79,6 +79,8 @@ is( $builder->alien_interpolate('%{double}'), "1", "MB helper overrides AB helpe
 is( $builder->alien_interpolate('%{argument_count1}'), "0", "argument count is zero (string helper)");
 is( $builder->alien_interpolate('%{argument_count2}'), "0", "argument count is zero (code helper)");
 
+is( $builder->alien_interpolate('%{pkg_config}'), Alien::Base::PkgConfig->pkg_config_command, "support for %{pkg_config}");
+
 done_testing;
 
 package


### PR DESCRIPTION
The idea is to avoid the user having to know that `Alien:Base::PkgConfig->pkg_config_command` is the magic incantation for determining the correct `pkg-config` (which could be either `pkg-config` or it could be `PkgConfig.pm`).  Example:

https://github.com/plicease/alien-sodium/commit/ab73d208fcd1343122aba11d699865dfb91fb116