### PR TITLE
add ALIEN_INSTALL_TYPE to force system install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ install:
   
   # for .travis-test-*
   - cpanm -n local::lib
+  
+  # for upgrade tests
+  - git fetch --unshallow
 
 perl:
   - "5.8"

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -50,6 +50,10 @@ $Verbose = $ENV{ALIEN_VERBOSE} if defined $ENV{ALIEN_VERBOSE};
 
 our $Force;
 $Force = $ENV{ALIEN_FORCE} if defined $ENV{ALIEN_FORCE};
+$Force = 1 if defined $ENV{ALIEN_INSTALL_TYPE} && $ENV{ALIEN_INSTALL_TYPE} eq 'share';
+
+our $ForceSystem;
+$ForceSystem = 1 if defined $ENV{ALIEN_INSTALL_TYPE} && $ENV{ALIEN_INSTALL_TYPE} eq 'system';
 
 ################
 #  Parameters  #
@@ -342,6 +346,10 @@ sub ACTION_alien_code {
       if defined $self->alien_provides_libs;
     $self->config_data( system_provides => \%system_provides );
     return;
+  }
+  
+  if ($ForceSystem) {
+    die "Requested system install, but system package not detected."
   }
 
   my @repos = $self->alien_create_repositories;

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -244,9 +244,13 @@ Setting the either to a true value will output a little more info from within th
 
 =item $Alien::Base::ModuleBuild::Force
 
+=item $ENV{ALIEN_INSTALL_TYPE}
+
+Setting to C<share> will ignore a system-wide installation and build a local version of the library.  Setting to C<system> will only use a system-wide installation and die if it cannot be found.
+
 =item $ENV{ALIEN_FORCE}
 
-Setting either to a true value will cause the builder to ignore a system-wide installation and build a local version of the library.
+Setting either to a true value will cause the builder to ignore a system-wide installation and build a local version of the library.  This is the equivalent to setting $ENV{ALIEN_INSTALL_TYPE} to 'share'.  $ENV{ALIEN_INSTALL_TYPE} takes precedence.
 
 =item $ENV{ALIEN_BLIB}
 


### PR DESCRIPTION
It is useful for system packagers to force a system install so they don't waste their time trying to build from source when creating .deb or .rpm files.

It may also be useful for the paranoid if they don't want to be downloading random packagers from the internet (some people differentiate between "cpan" and the "internet").

I didn't want to overload ALIEN_FORCE since ALIEN_FORCE=0 has never meant  system only.  Also ALIEN_INSTALL_TYPE takes priority since it is newer.

If this interface is acceptable we can phase out any reference to ALIEN_FORCE in the documentation and recommend ALIEN_INSTALL_TYPE.