### PR TITLE
use / instead of \ on relocated paths on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /Build
+/Build.bat
 /MYMETA.*
 /META.*
 _build/

--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -300,9 +300,11 @@ sub _keyword {
 
   if(defined $self->config('original_prefix') && $self->config('original_prefix') ne $self->dist_dir)
   {
+    my $dist_dir = $self->dist_dir;
+    $dist_dir =~ s{\\}{/}g if $^O eq 'MSWin32';
     my $old = quotemeta $self->config('original_prefix');
     @strings = map {
-      s{^(-I|-L|-LIBPATH:)?($old)}{$1.$self->dist_dir}e;
+      s{^(-I|-L|-LIBPATH:)?($old)}{$1.$dist_dir}e;
       s/(\s)/\\$1/g;
       $_;
     } map { $self->split_flags($_) } @strings;


### PR DESCRIPTION
This will fix errors like this:

http://www.cpantesters.org/cpan/report/8fd11466-6bf6-1014-a76b-fd2118e9470d