### PR TITLE
only do the alien install once

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -479,6 +479,7 @@ sub ACTION_alien_install {
     }
   }
 
+  if(!$self->config_data( 'finished_installing' ))
   {
     local $CWD = $self->config_data( 'working_directory' );
     local $ENV{DESTDIR} = $ENV{DESTDIR};


### PR DESCRIPTION
Currently when you run `Build test` or `Build install` on a staged install (where the `make install` gets run during the `Build` step into the blib directory) it runs `make install` first (or whatever the install command is).  This is really annoying as it spams the terminal with the redundant install.

This makes sure the `make install` only happens once, as it should.