### PR TITLE
make _env_do_system public renaming it to alien_do_system

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -687,7 +687,7 @@ sub _alien_bin_require {
   }
 }
 
-sub _env_do_system {
+sub alien_do_system {
   my $self = shift;
   my $command = shift;
   
@@ -776,6 +776,9 @@ sub _env_do_system {
   $self->do_system( ref($command) ? @$command : $command );
 }
 
+# alias for backwards compatibility
+*_env_do_system = \&alien_do_system;
+
 sub alien_check_built_version {
   return;
 }
@@ -791,7 +794,7 @@ sub alien_do_commands {
 
   foreach my $command (@$commands) {
 
-    my %result = $self->_env_do_system( $command );
+    my %result = $self->alien_do_system( $command );
     unless ($result{success}) {
       carp "External command ($result{command}) failed! Error: $?\n";
       return 0;
@@ -1246,6 +1249,19 @@ If you see an error message like this:
 
 After the package is built from source code then you probably need to
 provide an implementation for this method.
+
+=head2 alien_do_system
+
+  my %result = $amb->alien_do_system($cmd)
+
+Similar to L<Module::Build::do_system>, also sets the path and several
+environment variables in accordance to the object configuration
+(i.e. C<alien_bin_requires>) and performs the interpolation of the
+patterns described in L<Alien::Base::ModuleBuild::API/COMMAND
+INTERPOLATION>.
+
+Returns a set of key value pairs including C<stdout>, C<stderr>,
+C<success> and C<command>.
 
 =head1 GUIDE TO DOCUMENTATION
 


### PR DESCRIPTION
This method is usefull for users of the module wanting to run external
programs as it sets up the environment in accordance with the
configuration of the Alien::Base::ModuleBuild object.

An alias for _env_do_system has been added in order to keep backward
compatibility with programs using the old private method.