### PR TITLE
build_uri: fix URI composition

### DIFF
--- a/lib/Alien/Base/ModuleBuild/Repository/HTTP.pm
+++ b/lib/Alien/Base/ModuleBuild/Repository/HTTP.pm
@@ -129,26 +129,20 @@ sub find_links_textbalanced {
 
 sub build_uri {
   my $self = shift;
-  my ($protocol, $host, $path, $file) = @_;
+  my ($protocol, $host, $path, $target) = @_;
 
-  $protocol ||= 'http'; # if no protocol is passed, default to HTTP
-  my $uri = URI->new($file);
-  return $uri if $uri->scheme; # if an absolute URI
-
-  unless ( $host =~ m'^(?:https?|file)://' ) {
-    $host = "$protocol://$host";
+  my $uri;
+  if (defined $host) {
+    my $base = URI->new($host);
+    unless (defined $base->scheme) {
+      $base = URI->new(($protocol || 'http') ."://$host");
+    }
+    $base->path($path) if defined $path;
+    $uri = URI->new_abs($target, $base);
   }
-  $uri = URI->new( $host );
-  return $uri unless defined $path;
-
-  $path =~ s'/$'';
-  $uri->path( $path );
-  return $uri->canonical unless defined $file;
-
-  my @segments = $uri->path_segments;
-  shift @segments;
-  $uri->path_segments( @segments, $file );
-
+  else {
+    $uri = URI->new($target);
+  }
   return $uri->canonical;
 }
 

--- a/lib/Alien/Base/ModuleBuild/Repository/HTTP.pm
+++ b/lib/Alien/Base/ModuleBuild/Repository/HTTP.pm
@@ -50,8 +50,7 @@ sub get_file {
   my $from = $self->location;
 
   my $uri = $self->build_uri($protocol, $host, $from, $file);
-  # if it is an absolute URI, then use the filename from the URI
-  $file = ($uri->path_segments())[-1] if $file =~ /^(?:https?|file):/;
+  $file = ($uri->path_segments())[-1];
   my $res = $self->connection->mirror($uri, $file);
   my ( $is_error, $content, $headers ) = $self->check_http_response( $res );
   croak "Download failed: " . $content if $is_error;

--- a/t/http_uri.t
+++ b/t/http_uri.t
@@ -23,7 +23,7 @@ my $repo = Alien::Base::ModuleBuild::Repository::HTTP->new;
 }
 
 {
-  my $uri = $repo->build_uri('http','host.com', 'deeper', 'my path');
+  my $uri = $repo->build_uri('http','host.com', 'deeper/', 'my path');
   is $uri, 'http://host.com/deeper/my%20path', 'extended path with spaces';
 }
 
@@ -45,6 +45,12 @@ my $repo = Alien::Base::ModuleBuild::Repository::HTTP->new;
 {
   my $uri = $repo->build_uri('http','host.com/', '/path/', 'http://example.org/other/file.ext');
   is $uri, 'http://example.org/other/file.ext', 'absolute URI on different host';
+}
+
+{
+  my $uri = $repo->build_uri('https', 'github.com', '/libssh2/libssh2/releases/',
+                             '/libssh2/libssh2/releases/download/libssh2-1.6.0/libssh2-1.6.0.tar.gz');
+  is $uri, 'https://github.com/libssh2/libssh2/releases/download/libssh2-1.6.0/libssh2-1.6.0.tar.gz';
 }
 
 done_testing;


### PR DESCRIPTION
Rely as much as possible into the URI module when composing two URIs.

Before this patch, the code used was too simplistic and only covered
the more basic cases. Specifically it failed to handle the links from
GitHub release pages.

Also, one of the tests in http_uri.t was wrong.