### PR TITLE
ACTION_test: fix testing when using a system library

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -439,9 +439,13 @@ sub ACTION_test {
   my $self = shift;
   $self->SUPER::ACTION_test;
 
-  local $CWD = $self->config_data( 'working_directory' );
   print "Testing library (if applicable) ... ";
-  $self->alien_do_commands('test') or die "Failed\n";
+  if ($self->config_data( 'install_type' ) eq 'share') {
+    if (defined (my $wdir = $self->config_data( 'working_directory' ))) {
+      local $CWD = $wdir;
+      $self->alien_do_commands('test') or die "Failed\n";
+    }
+  }
   print "Done\n";
 }
 


### PR DESCRIPTION
The ACTION_test method was trying to run the library test suit even
when a system library has been detected (and so, no library was
actually compiled).