### PR TITLE
Fix verbose output being captured as command output

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -829,11 +829,14 @@ sub do_system {
 
   print "+ @args\n";
 
+  my $old_super_verbose = $self->verbose;
+  $self->verbose(0);
   my ($out, $err, $success) = 
     $verbose
     ? tee     { $self->SUPER::do_system(@args) }
     : capture { $self->SUPER::do_system(@args) }
   ;
+  $self->verbose($old_super_verbose);
 
   my %return = (
     stdout => $out,


### PR DESCRIPTION
Alien::Base::ModuleBuild::do_command captures the output from
Module::Build::Base::do_command, but the later may introduce debugging
output when Module::Build verbose mode is set.

This patch disables Mode::Build verbose mode before calling its
do_command method.