### PR TITLE
no warnings for dist with several .pc files

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -292,7 +292,8 @@ sub _keyword {
   # use parsed info from build .pc file
   my $dist_dir = $self->dist_dir;
   my @pc = $self->pkgconfig(@_);
-  my @strings = 
+  my @strings =
+    grep defined,
     map { $_->keyword($keyword, 
       #{ pcfiledir => $dist_dir }
     ) }

--- a/lib/Alien/Base/PkgConfig.pm
+++ b/lib/Alien/Base/PkgConfig.pm
@@ -101,8 +101,9 @@ sub _interpolate_vars {
       unless $override->{$key};
   }
 
-  1 while $string =~ s/\$\{(.*?)\}/$override->{$1} || $self->{vars}{$1}/e;
-
+  if (defined $string) {
+    1 while $string =~ s/\$\{(.*?)\}/$override->{$1} || $self->{vars}{$1}/e;
+  }
   return $string;
 }
 


### PR DESCRIPTION
For packages providing multiple libraries and so, multiple .pc files,
it is possible for some keys to not be defined in all of them.
Specifically, OpenSSL doesn't defined "Libs" in all the .pc files.

This change just silences a warning that was generated at runtime when
looking for a keyword not available in some .pc file.