### PR TITLE
Test success on version probe

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -551,7 +551,7 @@ sub alien_check_installed_version {
   my $command = $self->alien_version_check;
 
   my %result = $self->do_system($command, {verbose => 0});
-  my $version = $result{stdout} || 0;
+  my $version = ($result{success} && $result{stdout}) || 0;
 
   return $version;
 }


### PR DESCRIPTION
If the command fails, but there is some output we get a false positive.  This problem was discovered when using perl Build.PL verbose=1 (and demonstrated with Alien::LibYAML).  While this exact problem
will hopefully be fixed with PR #147, there are other strangeisms that could infect the captured output with bogus data.