### PR TITLE
%p and cmake

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl module Alien::Base.
 
+  - Deprecate %p
+
 0.027  Thu Feb 4, 2016
   - Production release identical to 0.026_02 release
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl module Alien::Base.
 
   - Deprecate %p
+  - Require Alien::CMake 0.07 as a minimum when used as alien_bin_requires
+    for Alien::Base compatability
 
 0.027  Thu Feb 4, 2016
   - Production release identical to 0.026_02 release

--- a/lib/Alien/Base/FAQ.pod
+++ b/lib/Alien/Base/FAQ.pod
@@ -279,7 +279,7 @@ install it for you.  You can use this from your C<Build.PL> with the C<alien_bin
  Alien::Base::ModuleBuild->new(
    ...
    alien_bin_requires => {
-     'Alien::CMake' => 0,
+     'Alien::CMake' => 0.07,
    },
    alien_build_commands => [
      # acutal required arguments may vary

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -194,7 +194,11 @@ sub new {
       $self->config_data( 'msys' => 0 );
     }
   
-    while(my($tool, $version) = each %{ $self->alien_bin_requires }) {
+    foreach my $tool (keys %{ $self->alien_bin_requires  }) {
+      my $version = $self->alien_bin_requires->{$tool};
+      if($tool eq 'Alien::CMake' && $version < 0.07) {
+        $version = '0.07';
+      }
       $self->_add_prereq( 'build_requires', $tool, $version );
     }
   }
@@ -721,8 +725,6 @@ sub alien_do_system {
     
     if ($mod eq 'Alien::MSYS') {
       $path{Alien::MSYS->msys_path} = 1;
-    } elsif ($mod eq 'Alien::CMake') {
-      Alien::CMake->set_path;
     } elsif ($mod eq 'Alien::TinyCC') {
       $path{Alien::TinyCC->path_to_tcc} = 1;
     } elsif ($mod eq 'Alien::Autotools') {

--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -208,6 +208,10 @@ sub new {
 
   $self->config_data( 'finished_installing' => 0 );
 
+  if(grep /(?<!\%)\%p/, map { ref($_) ? @{$_} : $_ } @{ $self->alien_build_commands }) {
+    carp "%p is deprecated, See https://metacpan.org/pod/distribution/Alien-Base/lib/Alien/Base/ModuleBuild/API.pod#p";
+  }
+
   return $self;
 }
 

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -412,7 +412,7 @@ If you are trying to invoke the autoconf configure script, use C<%c> instead.  T
 
 =item Some other script
 
-Invoke the interpreter directly.  For example, if you have a pythong script use "python foo.py", if you have a Perl script use "%X foo.pl", if you have an sh script use "sh foo.sh".  These are all portable.
+Invoke the interpreter directly.  For example, if you have a python script use "python foo.py", if you have a Perl script use "%X foo.pl", if you have an sh script use "sh foo.sh".  These are all portable.
 For sh, be sure to set the C<alien_msys> property so that it will work on Windows.
 
 =back

--- a/lib/Alien/Base/ModuleBuild/API.pod
+++ b/lib/Alien/Base/ModuleBuild/API.pod
@@ -396,9 +396,26 @@ Shortcut for the name stored in C<alien_name>
 
 =item %p
 
+B<deprecated>
+
 Platform independent "local command prefix". On *nix systems this is C<./>, on Windows it is an empty string.
 
  %pconfigure
+
+Please note that this only works to run scripts on Unix, and does not work on Windows.  It is thus, not fit for purpose and should not be used.  As an alternative:
+
+=over 4
+
+=item autoconf "configure"
+
+If you are trying to invoke the autoconf configure script, use C<%c> instead.  This will use the correct incantation on either Unix like systems and on Windows.
+
+=item Some other script
+
+Invoke the interpreter directly.  For example, if you have a pythong script use "python foo.py", if you have a Perl script use "%X foo.pl", if you have an sh script use "sh foo.sh".  These are all portable.
+For sh, be sure to set the C<alien_msys> property so that it will work on Windows.
+
+=back
 
 =item %s
 

--- a/t/builder.t
+++ b/t/builder.t
@@ -429,4 +429,32 @@ subtest 'alien_env' => sub {
   rmtree [qw/ _alien  _share  blib  src /], 0, 0;
 };
 
+subtest 'cmake' => sub {
+
+  subtest 'default' => sub {
+
+    my $builder = builder(
+      alien_bin_requires => { 'Alien::CMake' => 0 },
+      alien_build_commands => [],
+    );
+
+    isa_ok $builder, 'Alien::Base::ModuleBuild';
+    is $builder->build_requires->{"Alien::CMake"}, '0.07', 'require at least 0.07';
+    rmtree [qw/ _alien  _share  blib  src /], 0, 0;  
+  };
+
+  subtest 'more recent' => sub {
+
+    my $builder = builder(
+      alien_bin_requires => { 'Alien::CMake' => '0.10' },
+      alien_build_commands => [],
+    );
+
+    isa_ok $builder, 'Alien::Base::ModuleBuild';
+    is $builder->build_requires->{"Alien::CMake"}, '0.10', 'keep 0.10';
+    rmtree [qw/ _alien  _share  blib  src /], 0, 0;  
+  };
+  
+};
+
 done_testing;


### PR DESCRIPTION
Two minor cleanup items.

Officially deprecate `%p`.  Basically it isn't portable.  I have explained in other places why this really shouldn't ever be used, if anyone wants details let me know.

Use `Alien::CMake` 0.07 as a minimum when specified as a alien_bin_requires.  This version provides enough `Alien::Base` compatibility that it can be used as-is without any special case as an alien_bin_requires.