### PR TITLE
add trailing / when using exact filename

### DIFF
--- a/lib/Alien/Base/ModuleBuild/Repository.pm
+++ b/lib/Alien/Base/ModuleBuild/Repository.pm
@@ -20,6 +20,10 @@ sub new {
   $obj->{c_compiler_required} = 1
     unless defined $obj->{c_compiler_required};
 
+  if($obj->{exact_filename} && $obj->{location} !~ m{/$}) {
+    $obj->{location} .= '/'
+  }
+
   return $obj;
 }
 

--- a/t/repository.t
+++ b/t/repository.t
@@ -88,5 +88,33 @@ my $default = {
   }
 }
 
+subtest 'exact_filename trailing slash' => sub {
+
+  my $repo = Alien::Base::ModuleBuild::Repository->new(
+    protocol       => 'https',
+    host           => 'github.com',
+    location       => 'hunspell/hunspell/archive',
+    exact_filename => 'v1.3.4.tar.gz',
+  );
+  is $repo->location, 'hunspell/hunspell/archive/', 'exact filename implies trailing /';
+
+  $repo = Alien::Base::ModuleBuild::Repository->new(
+    protocol       => 'https',
+    host           => 'github.com',
+    location       => 'hunspell/hunspell/archive/',
+    exact_filename => 'v1.3.4.tar.gz',
+  );
+  is $repo->location, 'hunspell/hunspell/archive/', 'exact filename with trailing slash already there';
+
+  $repo = Alien::Base::ModuleBuild::Repository->new(
+    protocol       => 'https',
+    host           => 'github.com',
+    location       => 'hunspell/hunspell/archive',
+    pattern        => '^v([0-9\.]+).tar.gz$',
+  );
+  is $repo->location, 'hunspell/hunspell/archive', 'no exact filename does not imply trailing /';
+
+};
+
 done_testing;
 


### PR DESCRIPTION
This should address #161

Briefly, the issue is that:

 - When not using `exact_filename` we get the correct base URL because we look at the HTTP response on the index and will get the trailing slash if it is needed.
 - When using `exact_filename` we should append a trailing slash if it is not there already.  I can't think of a time when you wouldn't want to do this.