### PR TITLE
unset ALIEN_INSTALL_TYPE in test

### DIFF
--- a/t/builder.t
+++ b/t/builder.t
@@ -3,7 +3,11 @@ use warnings;
 
 use Test::More;
 
-BEGIN { delete $ENV{ACTIVESTATE_PPM_BUILD} }
+BEGIN {
+  delete $ENV{ACTIVESTATE_PPM_BUILD};
+  delete $ENV{ALIEN_INSTALL_TYPE};
+  delete $ENV{ALIEN_FORCE};
+}
 
 use Alien::Base::ModuleBuild;
 use File::chdir;


### PR DESCRIPTION
I just noticed, this test fails if ALIEN_INSTALL_TYPE is set to system.

```
t/builder.t ......................... 1/? Requested system install, but system package not detected. at /home/ollisg/dev/Alien-Base/lib/Alien/Base/ModuleBuild.pm line 371.
    # Child (destdir) exited without calling finalize()

#   Failed test 'destdir'
#   at /home/ollisg/perl5/perlbrew/perls/perl-5.22.1/lib/5.22.1/Test/Builder.pm line 279.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 1 just after 3.
t/builder.t ......................... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/3 subtests 
```