### PR TITLE
add a version method

### DIFF
--- a/lib/Alien/Base.pm
+++ b/lib/Alien/Base.pm
@@ -233,6 +233,22 @@ sub libs {
   return $self->_keyword('Libs', @_);
 }
 
+=head2 version
+
+ my $version = Alien::MyLibrary->version;
+
+Returns the version of the Alienized library or tool that was
+determined at install time.
+
+=cut
+
+sub version {
+  my $self = shift;
+  my $version = $self->config('version');
+  chomp $version;
+  return $version;
+}
+
 =head2 install_type
 
  my $install_type = Alien::MyLibrary->install_type;

--- a/t/alien_base.t
+++ b/t/alien_base.t
@@ -14,24 +14,28 @@ subtest 'AB::MB sys install' => sub {
 
   require_ok 'Alien::Foo1';
 
-  my $cflags = Alien::Foo1->cflags;
-  my $libs   = Alien::Foo1->libs;
+  my $cflags  = Alien::Foo1->cflags;
+  my $libs    = Alien::Foo1->libs;
+  my $version = Alien::Foo1->version;
 
   $libs =~ s{^\s+}{};
 
   is $cflags, '-DFOO=stuff', "cflags: $cflags";
   is $libs,   '-lfoo1', "libs: $libs";
+  is $version, '3.99999', "version: $version";
 };
 
 subtest 'AB::MB share install' => sub {
 
   require_ok 'Alien::Foo2';
 
-  my $cflags = Alien::Foo2->cflags;
-  my $libs   = Alien::Foo2->libs;
+  my $cflags  = Alien::Foo2->cflags;
+  my $libs    = Alien::Foo2->libs;
+  my $version = Alien::Foo2->version;
     
-  ok $cflags, "cflags: $cflags";
-  ok $libs,   "libs:   $libs";
+  ok $cflags,  "cflags: $cflags";
+  ok $libs,    "libs:   $libs";
+  is $version, '3.2.1', "version: $version";
 
   if($cflags =~ /-I(.*)$/)
   {


### PR DESCRIPTION
If I had a nickle for every time that I tried to call `$alien->version` then I would be able to afford to go to the movies in a theatre with nice large reserved seats.  This is my proposal to add a version method to get at the configuration data that is determined at install time.  It has the nice bonus that it shaves off the new line that may be there, because for system installs it just puts the output from `pkg-config --version` unless you have overridden the system detection logic.