### PR TITLE
Add required SSL modules for https

### DIFF
--- a/lib/Alien/Base/ModuleBuild.pm
+++ b/lib/Alien/Base/ModuleBuild.pm
@@ -203,6 +203,13 @@ sub new {
       }
       $self->_add_prereq( 'build_requires', $tool, $version );
     }
+
+    if($args{alien_repository}->{protocol} eq 'https')
+    {
+      $self->_add_prereq( 'build_requires', 'IO::Socket::SSL', '1.56' );
+      $self->_add_prereq( 'build_requires', 'Net::SSLeay',     '1.49' );
+    }
+
   }
 
 

--- a/t/builder.t
+++ b/t/builder.t
@@ -50,6 +50,21 @@ sub builder {
 #  Temporary Directories  #
 ###########################
 
+subtest 'http + ssl' => sub {
+
+  my $builder = builder(
+    alien_repository => {
+      protocol => 'https',
+      location => 'src',
+      c_compiler_required => 0,
+    },
+  );
+
+  is $builder->build_requires->{'IO::Socket::SSL'},     '1.56', 'SSL ~ IO::Socket::SSL 1.56 or better';
+  is $builder->build_requires->{'Net::SSLeay'},         '1.49', 'SSL ~ Net::SSLeay 1.49 or better';
+
+};
+
 subtest 'default temp and share' => sub {
   rmtree [qw/_alien _share/], 0, 1;
 


### PR DESCRIPTION
HTTP::Tiny can do SSL, but only if the appropriate modules are loaded.
The lack of this is largely responsible for most of the current failures
of Acme-Alien-DontPanic:

http://matrix.cpantesters.org/?dist=Acme-Alien-DontPanic%200.030

But all is good if we can inject the required ssl at the AB::MB level.