### PR TITLE
[PRC] Reorganize navigation of documentation

### DIFF
--- a/README
+++ b/README
@@ -22,8 +22,14 @@ Once installed you can read the project documentation using the perldoc
 command, or via the metacpan.org website.  If you are an Alien 
 developer, see the authoring documentation:
 
- perldoc Alien::Base::Authoring
- http://metacpan.org/pod/Alien::Base::Authoring
+ perldoc Alien::Base::ModuleBuild::Authoring
+ perldoc Alien::Build::Manual::AlienAuthor
+
+(this one installed in a separate module)
+
+ http://metacpan.org/pod/Alien::Base::ModuleBuild::Authoring
+ http://metacpan.org/pod/Alien::Build::Manual::AlienAuthor
+ 
 
 The FAQ also contains hints on dealing with specific challenges, like 
 dealing with specific tools:

--- a/README
+++ b/README
@@ -13,6 +13,11 @@ To install Alien::Base, use cpanminus:
 
  cpanm Alien::Base
  
+If you have downloaded this from GitHub or locally, do
+
+ cpanm --installdeps .
+ cpanm .
+
 Once installed you can read the project documentation using the perldoc 
 command, or via the metacpan.org website.  If you are an Alien 
 developer, see the authoring documentation:

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,3 @@
+requires "Alien::Base::ModuleBuild", ">=0.040";
+requires "FFI::CheckLib", ">=0.11";
+requires "Test2::Suite", ">=0.000060";

--- a/lib/Alien/Base/Authoring.pod
+++ b/lib/Alien/Base/Authoring.pod
@@ -10,15 +10,7 @@ Alien::Base::Authoring - Authoring an Alien distribution using Alien::Base
 =head1 DESCRIPTION
 
 This used to document the only way to author an L<Alien> distribution, which
-was with L<Aien::Base::ModuleBuild>.  You should now seriously consider using
-the newer more reliable method which is via L<Alien::Build> and L<alienfile>.
-
-=over 4
-
-=item L<Alien::Build::Manual::AlienAuthor>
-
-=item L<Alien::Base::ModuleBuild::Authoring>
-
-=back
+was with L<Alien::Base::ModuleBuild>.  You should now seriously consider using
+the newer more reliable method which is via L<Alien::Build> and L<alienfile>. Read all about it in L<Alien::Build::Manual::AlienAuthor> and L<Alien::Base::ModuleBuild::Authoring>
 
 =cut


### PR DESCRIPTION
Also adds `cpanfile` for easier local installation. I have navigated the documentation, noticed a possibly unneeded file (see #186 ) and reorganized pointers, as well as fixed a typo in this possibly unnecessary file. 
I can go ahead and try and test-drive the documentation as pointed out in #185 . I do use external dependencies for some of my modules. I will create a separate PR.